### PR TITLE
feat: Label, LabelText 공통 컴포넌트

### DIFF
--- a/packages/ui/components/Label.tsx
+++ b/packages/ui/components/Label.tsx
@@ -7,12 +7,12 @@ const LABEL_BACKGROUND_COLOR = {
   RED: 'red.400',
 } as const;
 
-type LabelProps = {
-  title: string;
+export type LabelProps = {
+  labelTitle: string;
   type?: keyof typeof LABEL_BACKGROUND_COLOR;
 };
 
-export default function Label({ title, type = 'GREEN' }: LabelProps) {
+export default function Label({ labelTitle, type = 'GREEN' }: LabelProps) {
   return (
     <Badge
       variant="solid"
@@ -20,7 +20,7 @@ export default function Label({ title, type = 'GREEN' }: LabelProps) {
       bgColor={LABEL_BACKGROUND_COLOR[type]}
       fontSize="sm"
     >
-      {title}
+      {labelTitle}
     </Badge>
   );
 }

--- a/packages/ui/components/Label.tsx
+++ b/packages/ui/components/Label.tsx
@@ -19,6 +19,8 @@ export default function Label({ labelTitle, type = 'GREEN' }: LabelProps) {
       color="white"
       bgColor={LABEL_BACKGROUND_COLOR[type]}
       fontSize="sm"
+      lineHeight="4"
+      textTransform="uppercase"
     >
       {labelTitle}
     </Badge>

--- a/packages/ui/components/Label.tsx
+++ b/packages/ui/components/Label.tsx
@@ -19,7 +19,7 @@ export default function Label({ labelTitle, type = 'GREEN' }: LabelProps) {
       color="white"
       bgColor={LABEL_BACKGROUND_COLOR[type]}
       fontSize="sm"
-      lineHeight="4"
+      lineHeight={4}
       textTransform="uppercase"
     >
       {labelTitle}

--- a/packages/ui/components/Label.tsx
+++ b/packages/ui/components/Label.tsx
@@ -1,0 +1,26 @@
+import { Badge } from '@chakra-ui/react';
+
+const LABEL_BACKGROUND_COLOR = {
+  GREEN: 'green.300',
+  ORANGE: 'orange.400',
+  YELLOW: 'yellow.300',
+  RED: 'red.400',
+} as const;
+
+type LabelProps = {
+  title: string;
+  type?: keyof typeof LABEL_BACKGROUND_COLOR;
+};
+
+export default function Label({ title, type = 'GREEN' }: LabelProps) {
+  return (
+    <Badge
+      variant="solid"
+      color="white"
+      bgColor={LABEL_BACKGROUND_COLOR[type]}
+      fontSize="sm"
+    >
+      {title}
+    </Badge>
+  );
+}

--- a/packages/ui/components/LabetText.tsx
+++ b/packages/ui/components/LabetText.tsx
@@ -9,7 +9,9 @@ export default function LabelText({ labelTitle, content }: LabelTextProps) {
   return (
     <HStack spacing="0.5rem">
       <Label labelTitle={labelTitle} />
-      <Text fontSize="sm">{content}</Text>
+      <Text fontSize="sm" lineHeight="4" textTransform="uppercase">
+        {content}
+      </Text>
     </HStack>
   );
 }

--- a/packages/ui/components/LabetText.tsx
+++ b/packages/ui/components/LabetText.tsx
@@ -9,7 +9,7 @@ export default function LabelText({ labelTitle, content }: LabelTextProps) {
   return (
     <HStack spacing="0.5rem">
       <Label labelTitle={labelTitle} />
-      <Text fontSize="sm" lineHeight="4" textTransform="uppercase">
+      <Text fontSize="sm" lineHeight={4} textTransform="uppercase">
         {content}
       </Text>
     </HStack>

--- a/packages/ui/components/LabetText.tsx
+++ b/packages/ui/components/LabetText.tsx
@@ -1,0 +1,15 @@
+import { HStack, Text } from '@chakra-ui/react';
+
+import type { LabelProps } from './Label';
+import Label from './Label';
+
+type LabelTextProps = { content: string } & LabelProps;
+
+export default function LabelText({ labelTitle, content }: LabelTextProps) {
+  return (
+    <HStack spacing="0.5rem">
+      <Label labelTitle={labelTitle} />
+      <Text fontSize="sm">{content}</Text>
+    </HStack>
+  );
+}


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #18
## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->
Label 및 LabelText 공통 컴포넌트를 구현했습니다.

### Label props
labelTitle: label에 들어갈 텍스트입니다
type: 배경색 타입입니다. 녹색, 주황색, 노란색, 빨간색의 타입이 있으며 기본값은 녹색으로 설정했습니다. 
``` ts
const LABEL_BACKGROUND_COLOR = {
  GREEN: 'green.300',
  ORANGE: 'orange.400',
  YELLOW: 'yellow.300',
  RED: 'red.400',
} as const;

export type LabelProps = {
  labelTitle: string;
  type?: keyof typeof LABEL_BACKGROUND_COLOR;
};
```

### LabelText props
labelTitle,type은 Label에 넣기 위해 입력해야 합니다
content : label 옆에 넣을 텍스트입니다
``` ts
type LabelTextProps = { content: string } & LabelProps;
```


## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
<img width="204" alt="label 및 labelText" src="https://github.com/Anifriends/Anifriends-Frontend/assets/43432783/0f66c4e2-0235-45c1-bfdb-c72dd3de7ea2">



## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
types 폴더는 현재 만들면 안될거 같아서 일단은 한 파일 내에 넣어놓았고 추후에 타입 분리 예정입니다.

