### PR TITLE
feat(ui): profileInfo 컴포넌트 제작

### DIFF
--- a/packages/ui/components/ProfileInfo.tsx
+++ b/packages/ui/components/ProfileInfo.tsx
@@ -15,7 +15,7 @@ export default function ProfileInfo({
 }: ProfileInfoProps) {
   return (
     <HStack spacing={5} py={3.5} align="flex-start">
-      <Avatar src={infoImage} boxSize="4.4rem" />
+      <Avatar src={infoImage} boxSize="71px" />
       <VStack align="left" gap={0}>
         <HStack align="center" spacing={3}>
           <Text fontSize="md" fontWeight="semibold">

--- a/packages/ui/components/ProfileInfo.tsx
+++ b/packages/ui/components/ProfileInfo.tsx
@@ -1,0 +1,39 @@
+import { Avatar, HStack, Text, VStack } from '@chakra-ui/react';
+
+type ProfileInfoProps = {
+  imageUrl?: string;
+  name: string;
+  email: string;
+  address?: string;
+  phoneNumber?: string;
+  children?: React.ReactNode;
+};
+
+export default function ProfileInfo({
+  imageUrl,
+  name,
+  email,
+  address,
+  phoneNumber,
+  children,
+}: ProfileInfoProps) {
+  return (
+    <HStack spacing={5} py={3.5} align="flex-start">
+      <Avatar src={imageUrl} boxSize="4.4rem" />
+      <VStack align="left" gap={0}>
+        <HStack align="center" spacing={3}>
+          <Text fontSize="md" fontWeight="semibold">
+            {name}
+          </Text>
+          {children}
+        </HStack>
+        <Text fontSize="sm" fontWeight="normal">
+          {email}
+        </Text>
+        <Text fontSize="sm" fontWeight="normal">
+          {address || phoneNumber}
+        </Text>
+      </VStack>
+    </HStack>
+  );
+}

--- a/packages/ui/components/ProfileInfo.tsx
+++ b/packages/ui/components/ProfileInfo.tsx
@@ -1,38 +1,34 @@
 import { Avatar, HStack, Text, VStack } from '@chakra-ui/react';
 
 type ProfileInfoProps = {
-  imageUrl?: string;
-  name: string;
-  email: string;
-  address?: string;
-  phoneNumber?: string;
+  infoImage?: string;
+  infoTitle: string;
+  infoTexts?: string[];
   children?: React.ReactNode;
 };
 
 export default function ProfileInfo({
-  imageUrl,
-  name,
-  email,
-  address,
-  phoneNumber,
+  infoImage,
+  infoTitle,
+  infoTexts,
   children,
 }: ProfileInfoProps) {
   return (
     <HStack spacing={5} py={3.5} align="flex-start">
-      <Avatar src={imageUrl} boxSize="4.4rem" />
+      <Avatar src={infoImage} boxSize="4.4rem" />
       <VStack align="left" gap={0}>
         <HStack align="center" spacing={3}>
           <Text fontSize="md" fontWeight="semibold">
-            {name}
+            {infoTitle}
           </Text>
           {children}
         </HStack>
-        <Text fontSize="sm" fontWeight="normal">
-          {email}
-        </Text>
-        <Text fontSize="sm" fontWeight="normal">
-          {address || phoneNumber}
-        </Text>
+        {infoTexts &&
+          infoTexts.map((infoText, index) => (
+            <Text key={index} fontSize="sm" fontWeight="normal">
+              {infoText}
+            </Text>
+          ))}
       </VStack>
     </HStack>
   );


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #22 
profileInfo 컴포넌트를 구현했습니다
## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->
### ProfileInfo props
imageUrl : 이미지 src 주소
name: 프로필 사용자의 이름
email: 프로필 사용자의 이메일
address: 프로필 사용자의 주소 ( 보호소프로필에서 사용합니다)
phoneNumber: 프로필 사용자의 핸드폰번호 (봉사자 프로필에서 사용합니다)
children: 온도 라벨 입니다.
```ts
type ProfileInfoProps = {
  imageUrl?: string;
  name: string;
  email: string;
  address?: string;
  phoneNumber?: string;
  children?: React.ReactNode;
};
```

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
<img width="377" alt="image" src="https://github.com/Anifriends/Anifriends-Frontend/assets/117665863/e4432e12-8e3a-439b-b01b-2e7c31a3ceb3">

프로필 이미지가 없는 사용자의 경우 차크라에서 제공하는 default 이미지를 보여줍니다.

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
<img width="429" alt="image" src="https://github.com/Anifriends/Anifriends-Frontend/assets/117665863/919b1f9d-c849-405a-8e3c-f6a3f1f861cc">

피그마에서 보호소 프로필에서 주소가 있는 경우도 있고 없는 경우도 있습니다. 
디자인에서 빠진건지 의도적으로 디자인된 작업인지 궁금합니다.
