### PR TITLE
feat: 보호소앱과 봉사자앱의 회원가입 페이지의 UI, useRadioGroup 훅, RadioGroup 컴포넌트 추가

### DIFF
--- a/apps/shelter/src/pages/signup/index.tsx
+++ b/apps/shelter/src/pages/signup/index.tsx
@@ -1,3 +1,153 @@
+import {
+  Box,
+  Button,
+  Center,
+  FormControl,
+  FormLabel,
+  HStack,
+  Icon,
+  Image,
+  Input,
+  InputGroup,
+  InputRightAddon,
+  InputRightElement,
+  Switch,
+  VStack,
+} from '@chakra-ui/react';
+import AnimalfriendsLogo from 'shared/assets/image-anifriends-logo.png';
+import IoEyeOff from 'shared/assets/IoEyeOff';
+import IoEyeSharp from 'shared/assets/IoEyeSharp';
+import useToggle from 'shared/hooks/useToggle';
+
 export default function SignupPage() {
-  return <h1>SignupPage</h1>;
+  const [isPasswordShow, togglePasswordShow] = useToggle();
+  const [isPasswordConfirmShow, togglePasswordConfirmShow] = useToggle();
+  const [isShelterAddressOpen, toggleShelterAddressOpen] = useToggle();
+
+  return (
+    <Box px={4} pb="104px">
+      <Center w="100%" py={10}>
+        <Image boxSize={160} borderRadius={100} src={AnimalfriendsLogo} />
+      </Center>
+      <form>
+        <FormControl mb={2} isRequired>
+          <FormLabel>이메일</FormLabel>
+          <InputGroup>
+            <Input placeholder="이메일을 입력하세요" type="email" />
+            <InputRightAddon as="button" bgColor="orange.400" color="white">
+              확인
+            </InputRightAddon>
+          </InputGroup>
+        </FormControl>
+        <FormControl mb={2} isRequired>
+          <FormLabel>비밀번호</FormLabel>
+          <InputGroup>
+            <Input
+              placeholder="비밀번호를 입력하세요"
+              type={isPasswordShow ? 'text' : 'password'}
+            />
+            <InputRightElement onClick={togglePasswordShow}>
+              <Icon as={isPasswordShow ? IoEyeOff : IoEyeSharp} />
+            </InputRightElement>
+          </InputGroup>
+        </FormControl>
+        <FormControl mb={2} isRequired>
+          <FormLabel>비밀번호 확인</FormLabel>
+          <InputGroup>
+            <Input
+              placeholder="비밀번호를 다시 입력하세요"
+              type={isPasswordConfirmShow ? 'text' : 'password'}
+            />
+            <InputRightElement onClick={togglePasswordConfirmShow}>
+              <Icon as={isPasswordConfirmShow ? IoEyeOff : IoEyeSharp} />
+            </InputRightElement>
+          </InputGroup>
+        </FormControl>
+        <FormControl mb={2} isRequired>
+          <FormLabel>보호소 이름</FormLabel>
+          <Input placeholder="보호소 이름을 입력하세요" type="text" />
+        </FormControl>
+        <FormControl mb={2} isRequired>
+          <FormLabel>보호소 주소</FormLabel>
+          <Input placeholder="보호소 주소를 입력하세요" type="text" />
+        </FormControl>
+        <FormControl mb={2} isRequired>
+          <HStack mb={2}>
+            <FormLabel flexShrink={0} m={0}>
+              보호소 상세주소
+            </FormLabel>
+            <FormControl as={HStack} spacing={1} justify="flex-end">
+              <FormLabel
+                pos="relative"
+                top="1px"
+                fontSize="14px"
+                color="gray.500"
+                m={0}
+              >
+                상세주소 공개
+              </FormLabel>
+              <Switch
+                colorScheme="orange"
+                isChecked={isShelterAddressOpen ? true : false}
+                onChange={toggleShelterAddressOpen}
+              />
+            </FormControl>
+          </HStack>
+          <Input placeholder="보호소 상세주소를 입력하세요" type="text" />
+        </FormControl>
+        <FormControl mb={2} isRequired>
+          <FormLabel>보호소 전화번호</FormLabel>
+          <Input placeholder="보호소 전화번호를 입력하세요" type="tel" />
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>보호소 임시 전화번호</FormLabel>
+          <Input placeholder="보호소 임시 전화번호를 입력하세요" type="tel" />
+        </FormControl>
+        <VStack
+          maxW="container.sm"
+          mx="auto"
+          px={4}
+          bgColor="white"
+          pos="fixed"
+          bottom={0}
+          left={0}
+          right={0}
+          py={2}
+          zIndex={10}
+          spacing={2}
+          align="stretch"
+        >
+          <Button
+            fontWeight="semibold"
+            bgColor="orange.400"
+            color="white"
+            type="submit"
+            _hover={{
+              bg: undefined,
+            }}
+            _active={{
+              bg: undefined,
+            }}
+          >
+            로그인
+          </Button>
+          <Button
+            fontWeight="semibold"
+            color="orange.400"
+            bgColor="inherit"
+            border="1px solid"
+            borderColor="orange.400"
+            _hover={{
+              bg: undefined,
+            }}
+            _active={{
+              bg: undefined,
+            }}
+          >
+            회원가입
+          </Button>
+        </VStack>
+      </form>
+    </Box>
+  );
 }

--- a/apps/volunteer/src/pages/signup/index.tsx
+++ b/apps/volunteer/src/pages/signup/index.tsx
@@ -83,8 +83,8 @@ export default function SignupPage() {
           <FormLabel>성별</FormLabel>
           <RadioGroup<GenderValue, GenderText>
             value={genderValue}
-            changeValue={changeGenderValue}
-            radioAttributes={[
+            onChange={changeGenderValue}
+            radios={[
               { value: 'MALE', text: '남성' },
               { value: 'FEMALE', text: '여성' },
             ]}

--- a/apps/volunteer/src/pages/signup/index.tsx
+++ b/apps/volunteer/src/pages/signup/index.tsx
@@ -1,3 +1,153 @@
+import {
+  Box,
+  Button,
+  Center,
+  FormControl,
+  FormLabel,
+  Icon,
+  Image,
+  Input,
+  InputGroup,
+  InputRightAddon,
+  InputRightElement,
+  VStack,
+} from '@chakra-ui/react';
+import AnimalfriendsLogo from 'shared/assets/image-anifriends-logo.png';
+import IoEyeOff from 'shared/assets/IoEyeOff';
+import IoEyeSharp from 'shared/assets/IoEyeSharp';
+import RadioGroup from 'shared/components/RadioGroup';
+import useRadioGroup from 'shared/hooks/useRadioGroup';
+import useToggle from 'shared/hooks/useToggle';
+
+type GenderValue = 'FEMALE' | 'MALE';
+
+type GenderText = '여성' | '남성';
+
 export default function SignupPage() {
-  return <h1>SignupPage</h1>;
+  const [isPasswordShow, togglePasswordShow] = useToggle();
+  const [isPasswordConfirmShow, togglePasswordConfirmShow] = useToggle();
+  const [genderValue, changeGenderValue] = useRadioGroup<GenderValue>('MALE');
+
+  return (
+    <Box px={4} pb="152px">
+      <Center w="100%" py={10}>
+        <Image boxSize={160} borderRadius={100} src={AnimalfriendsLogo} />
+      </Center>
+      <form>
+        <FormControl mb={2} isRequired>
+          <FormLabel>이메일</FormLabel>
+          <InputGroup>
+            <Input placeholder="이메일을 입력하세요" type="email" />
+            <InputRightAddon as="button" bgColor="orange.400" color="white">
+              확인
+            </InputRightAddon>
+          </InputGroup>
+        </FormControl>
+        <FormControl mb={2} isRequired>
+          <FormLabel>비밀번호</FormLabel>
+          <InputGroup>
+            <Input
+              placeholder="비밀번호를 입력하세요"
+              type={isPasswordShow ? 'text' : 'password'}
+            />
+            <InputRightElement onClick={togglePasswordShow}>
+              <Icon as={isPasswordShow ? IoEyeOff : IoEyeSharp} />
+            </InputRightElement>
+          </InputGroup>
+        </FormControl>
+        <FormControl mb={2} isRequired>
+          <FormLabel>비밀번호</FormLabel>
+          <InputGroup>
+            <Input
+              placeholder="비밀번호를 다시 입력하세요"
+              type={isPasswordConfirmShow ? 'text' : 'password'}
+            />
+            <InputRightElement onClick={togglePasswordConfirmShow}>
+              <Icon as={isPasswordConfirmShow ? IoEyeOff : IoEyeSharp} />
+            </InputRightElement>
+          </InputGroup>
+        </FormControl>
+        <FormControl mb={2} isRequired>
+          <FormLabel>이름</FormLabel>
+          <Input placeholder="이름을 입력하세요" type="text" />
+        </FormControl>
+        <FormControl mb={2} isRequired>
+          <FormLabel>생년월일</FormLabel>
+          <Input type="date" />
+        </FormControl>
+        <FormControl mb={2} isRequired>
+          <FormLabel>전화번호</FormLabel>
+          <Input placeholder="보호소 전화번호를 입력하세요" type="tel" />
+        </FormControl>
+        <FormControl mb={2} isRequired>
+          <FormLabel>성별</FormLabel>
+          <RadioGroup<GenderValue, GenderText>
+            value={genderValue}
+            changeValue={changeGenderValue}
+            radioAttributes={[
+              { value: 'MALE', text: '남성' },
+              { value: 'FEMALE', text: '여성' },
+            ]}
+          />
+        </FormControl>
+        <VStack
+          maxW="container.sm"
+          mx="auto"
+          px={4}
+          bgColor="white"
+          pos="fixed"
+          bottom={0}
+          left={0}
+          right={0}
+          py={2}
+          zIndex={10}
+          spacing={2}
+          align="stretch"
+        >
+          <Button
+            fontWeight="semibold"
+            bgColor="orange.400"
+            color="white"
+            type="submit"
+            _hover={{
+              bg: undefined,
+            }}
+            _active={{
+              bg: undefined,
+            }}
+          >
+            로그인
+          </Button>
+          <Button
+            fontWeight="semibold"
+            color="orange.400"
+            bgColor="inherit"
+            border="1px solid"
+            borderColor="orange.400"
+            _hover={{
+              bg: undefined,
+            }}
+            _active={{
+              bg: undefined,
+            }}
+          >
+            회원가입
+          </Button>
+          <Button
+            fontWeight="semibold"
+            bgColor="gray.100"
+            color="gray.500"
+            _hover={{
+              bg: undefined,
+            }}
+            _active={{
+              bg: undefined,
+            }}
+          >
+            비회원으로 사용하기
+          </Button>
+        </VStack>
+      </form>
+    </Box>
+  );
 }

--- a/packages/shared/components/RadioGroup.tsx
+++ b/packages/shared/components/RadioGroup.tsx
@@ -1,0 +1,55 @@
+import type {
+  RadioGroupProps as ChakraRadioGroupProps,
+  RadioProps,
+  StackProps,
+} from '@chakra-ui/react';
+import {
+  HStack,
+  Radio,
+  RadioGroup as ChakraRadioGroup,
+} from '@chakra-ui/react';
+
+type RadioAttributes<RadioValue, RadioText> = {
+  value: RadioValue;
+  text: RadioText;
+};
+
+type RadioGroupProps<RadioValue, RadioText> = {
+  value: RadioValue;
+  changeValue: (nextValue: RadioValue) => void;
+  radioAttributes: RadioAttributes<RadioValue, RadioText>[];
+  radioGroupProps?: ChakraRadioGroupProps;
+  hStackProps?: StackProps;
+  radioProps?: RadioProps;
+};
+
+export default function RadioGroup<
+  RadioValue extends string,
+  RadioText extends string,
+>({
+  value,
+  changeValue,
+  radioAttributes,
+  radioGroupProps,
+  hStackProps,
+  radioProps,
+}: RadioGroupProps<RadioValue, RadioText>) {
+  return (
+    <ChakraRadioGroup
+      value={value}
+      onChange={changeValue}
+      colorScheme="orange"
+      {...radioGroupProps}
+    >
+      <HStack spacing={16} {...hStackProps}>
+        {radioAttributes.map(
+          ({ value, text }: RadioAttributes<RadioValue, RadioText>) => (
+            <Radio key={value} value={value} {...radioProps}>
+              {text}
+            </Radio>
+          ),
+        )}
+      </HStack>
+    </ChakraRadioGroup>
+  );
+}

--- a/packages/shared/components/RadioGroup.tsx
+++ b/packages/shared/components/RadioGroup.tsx
@@ -9,46 +9,41 @@ import {
   RadioGroup as ChakraRadioGroup,
 } from '@chakra-ui/react';
 
-type RadioAttributes<RadioValue, RadioText> = {
-  value: RadioValue;
-  text: RadioText;
+type Radio<Value, Text> = {
+  value: Value;
+  text: Text;
 };
 
-type RadioGroupProps<RadioValue, RadioText> = {
-  value: RadioValue;
-  changeValue: (nextValue: RadioValue) => void;
-  radioAttributes: RadioAttributes<RadioValue, RadioText>[];
+type RadioGroupProps<Value, Text> = {
+  value: Value;
+  onChange: (nextValue: Value) => void;
+  radios: Radio<Value, Text>[];
   radioGroupProps?: ChakraRadioGroupProps;
   hStackProps?: StackProps;
   radioProps?: RadioProps;
 };
 
-export default function RadioGroup<
-  RadioValue extends string,
-  RadioText extends string,
->({
+export default function RadioGroup<Value extends string, Text extends string>({
   value,
-  changeValue,
-  radioAttributes,
+  onChange,
+  radios,
   radioGroupProps,
   hStackProps,
   radioProps,
-}: RadioGroupProps<RadioValue, RadioText>) {
+}: RadioGroupProps<Value, Text>) {
   return (
     <ChakraRadioGroup
       value={value}
-      onChange={changeValue}
+      onChange={onChange}
       colorScheme="orange"
       {...radioGroupProps}
     >
       <HStack spacing={16} {...hStackProps}>
-        {radioAttributes.map(
-          ({ value, text }: RadioAttributes<RadioValue, RadioText>) => (
-            <Radio key={value} value={value} {...radioProps}>
-              {text}
-            </Radio>
-          ),
-        )}
+        {radios.map(({ value, text }: Radio<Value, Text>) => (
+          <Radio key={value} value={value} {...radioProps}>
+            {text}
+          </Radio>
+        ))}
       </HStack>
     </ChakraRadioGroup>
   );

--- a/packages/shared/components/RadioGroup.tsx
+++ b/packages/shared/components/RadioGroup.tsx
@@ -14,11 +14,11 @@ type Radio<Value, Text> = {
   text: Text;
 };
 
-type RadioGroupProps<Value, Text> = {
+type RadioGroupProps<Value, Text> = Omit<ChakraRadioGroupProps, 'children'> & {
   value: Value;
   onChange: (nextValue: Value) => void;
+  defaultValue?: Value;
   radios: Radio<Value, Text>[];
-  radioGroupProps?: ChakraRadioGroupProps;
   hStackProps?: StackProps;
   radioProps?: RadioProps;
 };
@@ -26,17 +26,19 @@ type RadioGroupProps<Value, Text> = {
 export default function RadioGroup<Value extends string, Text extends string>({
   value,
   onChange,
+  defaultValue,
   radios,
-  radioGroupProps,
   hStackProps,
   radioProps,
+  ...chakraRadioGropRestprops
 }: RadioGroupProps<Value, Text>) {
   return (
     <ChakraRadioGroup
+      colorScheme="orange"
       value={value}
       onChange={onChange}
-      colorScheme="orange"
-      {...radioGroupProps}
+      defaultValue={defaultValue}
+      {...chakraRadioGropRestprops}
     >
       <HStack spacing={16} {...hStackProps}>
         {radios.map(({ value, text }: Radio<Value, Text>) => (

--- a/packages/shared/hooks/useRadioGroup.ts
+++ b/packages/shared/hooks/useRadioGroup.ts
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 
-const useRadioGroup = <RadioValue extends string>(
-  initialValue: RadioValue,
-): [RadioValue, (nextValue: RadioValue) => void] => {
-  const [value, setValue] = useState<RadioValue>(initialValue);
+const useRadioGroup = <Value extends string>(
+  initialValue: Value,
+): [Value, (nextValue: Value) => void] => {
+  const [value, setValue] = useState<Value>(initialValue);
 
-  const changeValue = (nextValue: RadioValue) => setValue(nextValue);
+  const changeValue = (nextValue: Value) => setValue(nextValue);
 
   return [value, changeValue];
 };

--- a/packages/shared/hooks/useRadioGroup.ts
+++ b/packages/shared/hooks/useRadioGroup.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+const useRadioGroup = <RadioValue extends string>(
+  initialValue: RadioValue,
+): [RadioValue, (nextValue: RadioValue) => void] => {
+  const [value, setValue] = useState<RadioValue>(initialValue);
+
+  const changeValue = (nextValue: RadioValue) => setValue(nextValue);
+
+  return [value, changeValue];
+};
+
+export default useRadioGroup;


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #69 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->

* [feat(shared): useRadioGroup 훅 추가](https://github.com/Anifriends/Anifriends-Frontend/commit/94db7597583ddc5d341df68cd49e9e4211a8f656)
* [feat(shared): RadioGroup 컴포넌트 추가](https://github.com/Anifriends/Anifriends-Frontend/commit/770eda54764358f7616c1d2c8abf59993e72ef75)
* [feat(shelter): SignupPage 컴포넌트 UI 추가](https://github.com/Anifriends/Anifriends-Frontend/commit/c67238198e72cc783eaa6bf9b927c704c5d28be4)
* [feat(volunteer): SignupPage 컴포넌트 UI 추가](https://github.com/Anifriends/Anifriends-Frontend/commit/dfb13ec4f56f9b3f06e1792ffa80c564a6f3d651)

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

### 봉사자앱

![화면-기록-2023-11-12-오전-3 09 27](https://github.com/Anifriends/Anifriends-Frontend/assets/66409882/6ed927da-0e74-4192-86dd-7ed9afb70354)

### 보호소앱

![화면-기록-2023-11-12-오전-3 10 46](https://github.com/Anifriends/Anifriends-Frontend/assets/66409882/18989bf1-bed6-43e2-ac5a-d045daf87258)


## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

### useRadioGroup, RadioGroup 사용법

<img width="364" alt="image" src="https://github.com/Anifriends/Anifriends-Frontend/assets/66409882/eac3b6ad-f337-4a43-b6fb-33b3adaae25f">


```tsx
import RadioGroup from 'shared/components/RadioGroup';
import useRadioGroup from 'shared/hooks/useRadioGroup';

type GenderValue = 'FEMALE' | 'MALE';

type GenderText = '여성' | '남성';

export default function SignupPage() {
  const [genderValue, changeGenderValue] = useRadioGroup<GenderValue>('MALE');

  return (
    <FormControl mb={2} isRequired>
      <FormLabel>성별</FormLabel>
      <RadioGroup<GenderValue, GenderText>
        value={genderValue}
        onChnage={changeGenderValue}
        radios={[
          { value: 'MALE', text: '남성' },
          { value: 'FEMALE', text: '여성' },
        ]}
      />
    </FormControl>
  )
}
```
chakra에서 기본적으로 같은 이름으로 useRadioGroup, RadioGroup를 제공하지만 우리 프로젝트 형식에 맞게 가공했습니다! 보호소, 봉사자 앱에서 쓰이는 경우를 발견해서 shared에 올렸습니다!

useRadioGroup와 RadioGroup를 세트로 사용하실 수 있습니다!!.
useRadioGroup가 반환하는 값들을 RadioGroup에서 그대로 props로 사용하기 때문이죠

모든 generic는 string 형식이지만 Union으로 넣으셔야합니다! 위 GenderValue, GenderText처럼 말이지요!
value에 해당하는 generic은 백엔드 api에 보내지는 즉 소통해야하는 갑을 넣으면 되고,
text에 해당하는 generic은 화면에 보여지는 값을 입력하면 됩니다.

![image](https://github.com/Anifriends/Anifriends-Frontend/assets/66409882/46d8e283-c7b0-4e02-8fd6-4ff8102e8b9e)

확장성을 고려해서 위 이미지와 같이 내부 구성이 되어있는 component(RadioGroup, Radio, HStack) 관련 props를 optional로 받게 하여 커스텀 할 수 있게 했습니다!

```tsx
 radios={[
   { value: 'MALE', text: '남성' },
   { value: 'FEMALE', text: '여성' },
 ]}
```
radios 당연히 type이 내부적으로 세팅이 되어있어 자동완성이 가능합니다!! 
편하게 사용하실 수 있습니다!!

## PR 정리

지금은 type, component들을 shared에 넣을 수 있는 것들은 제외하고 분리하지는 않았지만 추후 논의가 되어 구조가 확정이 되면 분리할 예정입니다!!

<img width="367" alt="image" src="https://github.com/Anifriends/Anifriends-Frontend/assets/66409882/37a74494-ce25-4745-8671-9ba070d84f27">

위 이미지는 봉사자의 회원가입 화면인데 확인 버튼만 우선 구현하고 확인 버튼을 클릭시 밑에 heplerText와 같은 형식으로 "사용하실 수 있는 이메일입니다" 혹은 확인을 했음에도 불구하고 다시 작성을 하기 시작하면 앞서 언급했던 문구는 사라지게 되고 이메일 형식을 검증하게 하기 위해 체크 표시 버튼은 넣지 않았습니다!!

<img width="366" alt="image" src="https://github.com/Anifriends/Anifriends-Frontend/assets/66409882/28af2a4c-e7aa-4cf2-8ec4-7d9f6c843e42">

전화번호와 같은 경우에도 옆에 아이콘을 넣지 않았는데 "전화번호" 라는 문구 자체가 전화번호를 적으라고 사용자에게 알려주기도 하고 아이콘이 어떠한 기능을 하지 않기 떄문에 불필요한 요소라 생각하여 생략하였습니다! 다른 의견이 있다면 말씀해주시면 감사하겠습니다! 🙋🏻‍♂️

마지막으로 PR이 머지가 되면 바로 로직을 구현하고, 컴포넌트 분리 PR를 할 예정입니다!!

(오타가 있는데 로직 구현할 때 반영하겠습니다!) 
