### PR TITLE
bug: 공통 레이아웃 컴포넌트 UI 깨짐 현상 수정

### DIFF
--- a/packages/shared/layout/Header/DefaultHeader/index.tsx
+++ b/packages/shared/layout/Header/DefaultHeader/index.tsx
@@ -24,6 +24,7 @@ export default function DefaultHeader({ appType }: HeaderProps) {
       color="white"
       lineHeight={6}
       pos="sticky"
+      zIndex={10}
       w="100%"
       py={2.5}
       justify="center"

--- a/packages/shared/layout/Header/DetailHeader/index.tsx
+++ b/packages/shared/layout/Header/DetailHeader/index.tsx
@@ -36,6 +36,7 @@ export default function DetailHeader({ appType }: HeaderProps) {
       borderBottom="1px solid"
       borderColor="gray.200"
       pos="sticky"
+      zIndex={10}
       w="100%"
       py={2.5}
       justify="center"

--- a/packages/shared/layout/Header/SearchHeader/index.tsx
+++ b/packages/shared/layout/Header/SearchHeader/index.tsx
@@ -34,6 +34,7 @@ export default function SearchHeader() {
       borderBottom="1px solid"
       borderColor="gray.200"
       pos="sticky"
+      zIndex={10}
       w="100%"
       h="44px"
       p="5px 16px"

--- a/packages/shared/layout/index.tsx
+++ b/packages/shared/layout/index.tsx
@@ -13,7 +13,7 @@ export default function Layout({ appType }: LayoutProps) {
   return (
     <Container pos="relative" maxW="container.sm" h="100vh" p={0} centerContent>
       <Header appType={appType} />
-      <Box width="100%" height="100%" pb="50px" as="main">
+      <Box overflowY="scroll" width="100%" height="100%" mb="50px" as="main">
         <Outlet />
       </Box>
       <BottomNavBar />

--- a/packages/shared/theme/index.ts
+++ b/packages/shared/theme/index.ts
@@ -5,6 +5,13 @@ const theme = extendTheme({
     heading: `'Pretendard-Heading'`,
     body: `'Pretendard-Body'`,
   },
+  styles: {
+    global: {
+      body: {
+        'overscroll-behavior': 'none',
+      },
+    },
+  },
 });
 
 export default theme;


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #78 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->
- 공통 레이아웃의 contents 부분에 overflowY scroll 속성을 추가했습니다
- 공통 레이아웃 header 컴포넌트에 zIndex 를 10씩 추가했습니다
- overscroll-behavior 을 none 으로 변경하여 default scroll 이벤트를 막았습니다

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
