### PR TITLE
design(shared): 공통 레이아웃 컴포넌트의 margin bottom 제거

### DIFF
--- a/packages/shared/layout/index.tsx
+++ b/packages/shared/layout/index.tsx
@@ -13,7 +13,7 @@ export default function Layout({ appType }: LayoutProps) {
   return (
     <Container pos="relative" maxW="container.sm" h="100vh" p={0} centerContent>
       <Header appType={appType} />
-      <Box overflowY="scroll" width="100%" height="100%" mb="50px" as="main">
+      <Box overflowY="scroll" width="100%" height="100%" as="main">
         <Outlet />
       </Box>
       <BottomNavBar />


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #94 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->

`BottomNavBar` 가 없는 경우에는 margin bottom 이 필요하지 않아서,
`BottomNavBar` 가 있는 경우에는 각 페이지에 margin bottom 을 추가해주어야 할 것 같습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
