### PR TITLE
feat(shelter): 보호소 마이페이지 msw 연결

### DIFF
--- a/apps/shelter/src/apis/shelter.ts
+++ b/apps/shelter/src/apis/shelter.ts
@@ -1,31 +1,14 @@
 import axiosInstance from 'shared/apis/axiosInstance';
 
-type ShelterInfo = {
-  name: string;
-  imageUrl: string;
-  address: string;
-  addressDetail: string;
-  phoneNumber: string;
-  sparePhoneNumber: string;
-  isOpenedAddress: boolean;
-};
+import { ShelterInfo } from '@/types/apis/shetler';
 
 type PasswordUpdateParams = {
   newPassword: string;
   oldPassword: string;
 };
 
-export const getShelterInfo = () =>
-  axiosInstance.get<{
-    shelterId: number;
-    shelterName: string;
-    shelterImageUrl: string;
-    shelterAddress: string;
-    shelterAddressDetail: string;
-    shelterPhoneNumber: string;
-    shelterSparePhoneNumber: string;
-    shelterIsOpenedAddress: boolean;
-  }>('/shelters/me');
+export const getShelterInfoAPI = () =>
+  axiosInstance.get<ShelterInfo>('/shelters/me');
 
 export const updateShelterInfo = (shelterInfo: ShelterInfo) =>
   axiosInstance.patch<unknown, ShelterInfo>('/shelters/me', shelterInfo);
@@ -36,7 +19,7 @@ export const updatePassword = (passwordUpdateParams: PasswordUpdateParams) =>
     passwordUpdateParams,
   );
 
-export const updateAddressStatus = (isOpenedAddress: boolean) =>
+export const updateAddressStatusAPI = (isOpenedAddress: boolean) =>
   axiosInstance.patch<
     unknown,
     {

--- a/apps/shelter/src/mocks/browser.ts
+++ b/apps/shelter/src/mocks/browser.ts
@@ -1,5 +1,6 @@
 import { setupWorker } from 'msw/browser';
 
-import { handlers } from './handlers/auth';
+import { handlers as authHandlers } from './handlers/auth';
+import { handlers as shelterHandlers } from './handlers/shelter';
 
-export const worker = setupWorker(...handlers);
+export const worker = setupWorker(...authHandlers, ...shelterHandlers);

--- a/apps/shelter/src/mocks/handlers/shelter.ts
+++ b/apps/shelter/src/mocks/handlers/shelter.ts
@@ -1,0 +1,25 @@
+import { delay, http, HttpResponse } from 'msw';
+
+export const handlers = [
+  http.get('/shelters/me', async () => {
+    await delay(200);
+    return HttpResponse.json(
+      {
+        shelterId: 1,
+        shelterEmail: 'Shelter1234@gmail.com',
+        shelterName: '양천구 보호소',
+        imageUrl: null,
+        shelterAddress: '서울특별시 양천구',
+        shelterAddressDetail: '서울특별시 양천구 신월동 동자빌딩',
+        shelterPhoneNumber: '010-1234-5678',
+        shelterSparePhoneNumber: '02-345-6780',
+        shelterIsOpenedAddress: true,
+      },
+      { status: 200 },
+    );
+  }),
+  http.patch('/shelters/me/address/status', async () => {
+    await delay(200);
+    return HttpResponse.json({ status: 200 });
+  }),
+];

--- a/apps/shelter/src/pages/my/_hooks/useMyPage.ts
+++ b/apps/shelter/src/pages/my/_hooks/useMyPage.ts
@@ -1,0 +1,68 @@
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { getShelterInfoAPI, updateAddressStatusAPI } from '@/apis/shelter';
+import { ShelterInfo } from '@/types/apis/shetler';
+
+type ShelterProfile = {
+  shelterName: string;
+  email: string;
+  phoneNumber: string;
+  sparePhoneNumber: string;
+  shelterAddress: string;
+  isAddressPublic: boolean;
+};
+
+const createProfile = (response: ShelterInfo): ShelterProfile => {
+  const {
+    shelterName,
+    shelterEmail,
+    shelterPhoneNumber,
+    shelterSparePhoneNumber,
+    shelterAddressDetail,
+    shelterIsOpenedAddress,
+  } = response;
+  return {
+    shelterName: shelterName,
+    email: shelterEmail,
+    phoneNumber: shelterPhoneNumber,
+    sparePhoneNumber: shelterSparePhoneNumber,
+    shelterAddress: shelterAddressDetail,
+    isAddressPublic: shelterIsOpenedAddress,
+  };
+};
+
+export const useMyPage = () => {
+  const [isAddressPublic, setIsAddressPublic] = useState(false);
+
+  const getShelterInfo = async (): Promise<ShelterProfile> => {
+    const response = await getShelterInfoAPI();
+    setIsAddressPublic(response.shelterIsOpenedAddress);
+
+    return createProfile(response);
+  };
+
+  const updateAddressStatus = async () => {
+    try {
+      await updateAddressStatusAPI(!isAddressPublic);
+      setIsAddressPublic(!isAddressPublic);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const { data } = useQuery({
+    queryKey: ['shelterProfile'],
+    queryFn: getShelterInfo,
+    initialData: {
+      shelterName: '',
+      email: '',
+      phoneNumber: '',
+      sparePhoneNumber: '',
+      shelterAddress: '',
+      isAddressPublic: false,
+    },
+  });
+
+  return { shelterProfile: data, isAddressPublic, updateAddressStatus };
+};

--- a/apps/shelter/src/pages/my/_hooks/useMyPage.ts
+++ b/apps/shelter/src/pages/my/_hooks/useMyPage.ts
@@ -35,13 +35,6 @@ const createProfile = (response: ShelterInfo): ShelterProfile => {
 export const useMyPage = () => {
   const [isAddressPublic, setIsAddressPublic] = useState(false);
 
-  const getShelterInfo = async (): Promise<ShelterProfile> => {
-    const response = await getShelterInfoAPI();
-    setIsAddressPublic(response.shelterIsOpenedAddress);
-
-    return createProfile(response);
-  };
-
   const updateAddressStatus = async () => {
     try {
       await updateAddressStatusAPI(!isAddressPublic);
@@ -53,7 +46,12 @@ export const useMyPage = () => {
 
   const { data } = useQuery({
     queryKey: ['shelterProfile'],
-    queryFn: getShelterInfo,
+    queryFn: async () => {
+      const response = (await getShelterInfoAPI()).data;
+      setIsAddressPublic(response.shelterIsOpenedAddress);
+
+      return createProfile(response);
+    },
     initialData: {
       shelterName: '',
       email: '',

--- a/apps/shelter/src/pages/my/index.tsx
+++ b/apps/shelter/src/pages/my/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Divider, Switch, VStack } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import InfoItem from 'shared/components/InfoItem';
 import InfoList from 'shared/components/InfoList';
@@ -7,28 +6,14 @@ import InfoTextItem from 'shared/components/InfoTextItem';
 import ProfileInfo from 'shared/components/ProfileInfo';
 import SettingGroup from 'shared/components/SettingGroup';
 
+import { useMyPage } from '@/pages/my/_hooks/useMyPage';
+
 export default function MyPage() {
   const navigate = useNavigate();
-  const [profile, setProfile] = useState({
-    shelterName: '',
-    email: '',
-    phoneNumber: '',
-    sparePhoneNumber: '',
-    shelterAddress: '',
-  });
-
-  useEffect(() => {
-    setProfile({
-      shelterName: '양천구 보호소',
-      email: 'Shelter1234@gmail.com',
-      phoneNumber: '010-1234-5678',
-      sparePhoneNumber: '02-345-6780',
-      shelterAddress: '서울특별시 양천구 신월동 동자빌딩',
-    });
-  }, [setProfile]);
+  const { shelterProfile, isAddressPublic, updateAddressStatus } = useMyPage();
 
   const { shelterName, email, phoneNumber, sparePhoneNumber, shelterAddress } =
-    profile;
+    shelterProfile;
 
   const goShelterReview = () => navigate('/mypage/reviews');
   const goSettingsAccount = () => navigate('/settings/account');
@@ -46,7 +31,11 @@ export default function MyPage() {
         <InfoTextItem title="전화번호(임시)" content={sparePhoneNumber} />
         <InfoTextItem title="상세주소" content={shelterAddress} />
         <InfoItem title="상세주소 공개">
-          <Switch size="sm" />
+          <Switch
+            size="sm"
+            isChecked={isAddressPublic}
+            onChange={updateAddressStatus}
+          />
         </InfoItem>
       </InfoList>
       <VStack mt={8} spacing={8} align="stretch">

--- a/apps/shelter/src/types/apis/shetler.ts
+++ b/apps/shelter/src/types/apis/shetler.ts
@@ -1,0 +1,11 @@
+export type ShelterInfo = {
+  shelterId: number;
+  shelterEmail: string;
+  shelterName: string;
+  shelterImageUrl: string;
+  shelterAddress: string;
+  shelterAddressDetail: string;
+  shelterPhoneNumber: string;
+  shelterSparePhoneNumber: string;
+  shelterIsOpenedAddress: boolean;
+};

--- a/packages/shared/apis/axiosInstance.ts
+++ b/packages/shared/apis/axiosInstance.ts
@@ -44,25 +44,22 @@ class AxiosService {
     url: string,
     config?: AxiosRequestConfig<Request>,
   ) {
-    return this.axiosInstance.get<Response>(url, config) as Promise<Response>;
+    return this.axiosInstance.get<Response>(url, config);
   }
 
   post<Response = unknown, Request = unknown>(url: string, data?: Request) {
-    return this.axiosInstance.post<Response>(url, data) as Promise<Response>;
+    return this.axiosInstance.post<Response>(url, data);
   }
 
   delete<Response = unknown, Request = unknown>(
     url: string,
     config?: AxiosRequestConfig<Request>,
   ) {
-    return this.axiosInstance.delete<Response>(
-      url,
-      config,
-    ) as Promise<Response>;
+    return this.axiosInstance.delete<Response>(url, config);
   }
 
   patch<Response = unknown, Request = unknown>(url: string, data?: Request) {
-    return this.axiosInstance.patch<Response>(url, data) as Promise<Response>;
+    return this.axiosInstance.patch<Response>(url, data);
   }
 }
 

--- a/packages/shared/apis/axiosInstance.ts
+++ b/packages/shared/apis/axiosInstance.ts
@@ -44,22 +44,25 @@ class AxiosService {
     url: string,
     config?: AxiosRequestConfig<Request>,
   ) {
-    return this.axiosInstance.get<Response>(url, config);
+    return this.axiosInstance.get<Response>(url, config) as Promise<Response>;
   }
 
   post<Response = unknown, Request = unknown>(url: string, data?: Request) {
-    return this.axiosInstance.post<Response>(url, data);
+    return this.axiosInstance.post<Response>(url, data) as Promise<Response>;
   }
 
   delete<Response = unknown, Request = unknown>(
     url: string,
     config?: AxiosRequestConfig<Request>,
   ) {
-    return this.axiosInstance.delete<Response>(url, config);
+    return this.axiosInstance.delete<Response>(
+      url,
+      config,
+    ) as Promise<Response>;
   }
 
   patch<Response = unknown, Request = unknown>(url: string, data?: Request) {
-    return this.axiosInstance.patch<Response>(url, data);
+    return this.axiosInstance.patch<Response>(url, data) as Promise<Response>;
   }
 }
 


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #79 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->
- 보호소 프로필 조회 기능
- 보호소 프로필 상세주소 공개/비공개 토글

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

<img width="380" alt="image" src="https://github.com/Anifriends/Anifriends-Frontend/assets/74397358/8535b2d2-eb21-472f-bf36-74914f72ff85">


## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- `axiosInstance` 의 response `interceptor` 가 `response.data` 를 반환하므로, get, post, delete, patch 함수의 return 타입이 `Promise<Response>`가 되어야 하나, 타입스크립트에서 `Promise<AxiosResponse<Response>>` 로 자동 타입 추론되어 타입 에러가 발생
  ->  이를 해결하기 위해 return 문에 타입 단언을 추가했습니다.
  -> 팀 논의 후, axios response interceptor 제거 및 AxiosResponse 에서 data 만 뽑아서 반환하는 기능 제거하기로 결정
- api 함수는 함수 뒤에 API postfix 를 추가하여, 함수명 중복을 피하고, API 함수임을 명확하게 드러내고자 했습니다.
