### PR TITLE
feat(shelter): 봉사자 모집 검색 페이지 msw 연결

### DIFF
--- a/apps/shelter/src/apis/recruitment.ts
+++ b/apps/shelter/src/apis/recruitment.ts
@@ -16,16 +16,21 @@ export type Recruitment = {
   recruitmentCapacity: number;
 };
 
-type RecruitSearchParams = {
+export type RecruitSearchFilter = Partial<{
   keyword: string;
   startDate: string;
   endDate: string;
   isClosed: boolean;
   content: boolean;
   title: boolean;
+}>;
+
+export type Pagination = {
   pageSize: number;
   pageNumber: number;
 };
+
+type RecruitSearchParams = RecruitSearchFilter & Pagination;
 
 export type RecruitmentSearchResponse = {
   pageInfo: PageInfo;

--- a/apps/shelter/src/apis/recruitment.ts
+++ b/apps/shelter/src/apis/recruitment.ts
@@ -1,11 +1,11 @@
 import axiosInstance from 'shared/apis/axiosInstance';
 
-type PageInfo = {
+export type PageInfo = {
   totalElements: number;
   hasNext: boolean;
 };
 
-type Recruitment = {
+export type Recruitment = {
   recruitmentId: number;
   recruitmentTitle: string;
   recruitmentStartTime: string;
@@ -25,6 +25,12 @@ type RecruitSearchParams = {
   title: boolean;
   pageSize: number;
   pageNumber: number;
+};
+
+export type RecruitmentSearchResponse = {
+  pageInfo: PageInfo;
+  recruitments: Recruitment[];
+  offset?: number;
 };
 
 type PostRecruitmentParams = {
@@ -48,20 +54,12 @@ type RecruitementStatus = 'PENDING' | 'REFUSED' | 'APPROVED';
 export const getShelterRecruitments = async (
   recruitSearchParams: Partial<RecruitSearchParams>,
 ) => {
-  console.log(recruitSearchParams);
-  const data = await axiosInstance.get<
-    {
-      pageInfo: PageInfo;
-      recruitments: Recruitment[];
-    },
+  const { data } = await axiosInstance.get<
+    RecruitmentSearchResponse,
     RecruitSearchParams
-  >('/shelters/recruitments', {
-    params: recruitSearchParams,
-  });
-  return {
-    ...data,
-    offset: recruitSearchParams.pageNumber,
-  };
+  >('/shelters/recruitments', { params: recruitSearchParams });
+
+  return { ...data, offset: recruitSearchParams.pageNumber };
 };
 
 export const createShelterRecruitment = (

--- a/apps/shelter/src/pages/volunteers/_components/RecruitDateText.tsx
+++ b/apps/shelter/src/pages/volunteers/_components/RecruitDateText.tsx
@@ -11,5 +11,5 @@ export default function RecruitDateText({
   date,
   time,
 }: RecruitDateTextProps) {
-  return <Text fontSize="xs">{`${title} | ${date} • ${time}`}</Text>;
+  return <Text fontSize="xs">{`${title} | ${date} · ${time}`}</Text>;
 }

--- a/apps/shelter/src/pages/volunteers/_components/RecruitItem.tsx
+++ b/apps/shelter/src/pages/volunteers/_components/RecruitItem.tsx
@@ -83,7 +83,7 @@ export default function RecruitItem({
               title="봉사일시"
               date={`${createFormattedTime(
                 new Date(recruitmentStartTime),
-                'YYYY.MM.DD.',
+                'YYYY.MM.DD',
               )}`}
               time={`${createFormattedTime(
                 new Date(recruitmentStartTime),
@@ -95,7 +95,7 @@ export default function RecruitItem({
                 title="마감일시"
                 date={`${createFormattedTime(
                   new Date(recruitmentDeadline),
-                  'YYYY.MM.DD.',
+                  'YYYY.MM.DD',
                 )}`}
                 time={`${createFormattedTime(
                   new Date(recruitmentDeadline),

--- a/apps/shelter/src/pages/volunteers/hooks/useFetchVolunteers.tsx
+++ b/apps/shelter/src/pages/volunteers/hooks/useFetchVolunteers.tsx
@@ -7,10 +7,12 @@ import {
 import {
   getShelterRecruitments,
   RecruitmentSearchResponse,
+  RecruitSearchFilter,
 } from '@/apis/recruitment';
 
 export default function useFetchVolunteers(
   pageSize: number,
+  filter?: RecruitSearchFilter,
 ): UseSuspenseInfiniteQueryResult<
   InfiniteData<RecruitmentSearchResponse>,
   Error
@@ -18,7 +20,7 @@ export default function useFetchVolunteers(
   return useSuspenseInfiniteQuery({
     queryKey: ['recruitments'],
     queryFn: ({ pageParam }) =>
-      getShelterRecruitments({ pageNumber: pageParam, pageSize }),
+      getShelterRecruitments({ pageNumber: pageParam, pageSize, ...filter }),
     initialPageParam: 0,
     getNextPageParam: ({ pageInfo }, _, lastPageParam) =>
       pageInfo.hasNext ? lastPageParam + 1 : null,

--- a/apps/shelter/src/pages/volunteers/hooks/useFetchVolunteers.tsx
+++ b/apps/shelter/src/pages/volunteers/hooks/useFetchVolunteers.tsx
@@ -1,14 +1,26 @@
-import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import {
+  InfiniteData,
+  useSuspenseInfiniteQuery,
+  UseSuspenseInfiniteQueryResult,
+} from '@tanstack/react-query';
 
-import { getShelterRecruitments } from '@/apis/recruitment';
+import {
+  getShelterRecruitments,
+  RecruitmentSearchResponse,
+} from '@/apis/recruitment';
 
-export default function useFetchVolunteers(pageSize: number) {
+export default function useFetchVolunteers(
+  pageSize: number,
+): UseSuspenseInfiniteQueryResult<
+  InfiniteData<RecruitmentSearchResponse>,
+  Error
+> {
   return useSuspenseInfiniteQuery({
     queryKey: ['recruitments'],
     queryFn: ({ pageParam }) =>
       getShelterRecruitments({ pageNumber: pageParam, pageSize }),
     initialPageParam: 0,
-    getNextPageParam: ({ data: { pageInfo } }, _, lastPageParam) =>
+    getNextPageParam: ({ pageInfo }, _, lastPageParam) =>
       pageInfo.hasNext ? lastPageParam + 1 : null,
   });
 }

--- a/apps/shelter/src/pages/volunteers/index.tsx
+++ b/apps/shelter/src/pages/volunteers/index.tsx
@@ -32,7 +32,7 @@ function Recruitments() {
     fetchNextPage,
   } = useFetchVolunteers(PAGE_SIZE);
 
-  const recruitments = pages.flatMap(({ data }) => data.recruitments);
+  const recruitments = pages.flatMap(({ recruitments }) => recruitments);
 
   const ref = useIntersect(async (entry, observer) => {
     observer.unobserve(entry.target);

--- a/apps/shelter/src/pages/volunteers/search/_hooks/useSearchFilter.ts
+++ b/apps/shelter/src/pages/volunteers/search/_hooks/useSearchFilter.ts
@@ -10,21 +10,14 @@ const parseSearchParams = (searchParams: URLSearchParams) => {
   return params;
 };
 
-export const useSearchFilter = <SearchFilter extends object>(
-  onSearch: (filter: SearchFilter) => void,
-): [SearchFilter, (filter: SearchFilter) => void] => {
+export const useSearchFilter = <SearchFilter extends object>(): [
+  SearchFilter,
+  (filter: SearchFilter) => void,
+] => {
   const setKeyword = useSearchHeaderStore((state) => state.setKeyword);
 
   const [filter, setFilter] = useState<SearchFilter>({} as SearchFilter);
   const [searchParams, setSearchParams] = useSearchParams();
-
-  useEffect(() => {
-    if (Object.keys(filter).length === 0) {
-      return;
-    }
-
-    onSearch(filter);
-  }, [filter, onSearch]);
 
   useEffect(() => {
     if (searchParams.size === 0) {
@@ -53,8 +46,10 @@ export const useSearchFilter = <SearchFilter extends object>(
     );
   };
 
-  const setFilterValue = (filter: SearchFilter) => {
-    setSearchParams(createSearchParams(filter), { replace: true });
+  const setFilterValue = (newFilter: SearchFilter) => {
+    setSearchParams(createSearchParams({ ...filter, ...newFilter }), {
+      replace: true,
+    });
     setFilter(filter);
   };
 

--- a/apps/shelter/src/pages/volunteers/search/_hooks/useVolunteerSearch.ts
+++ b/apps/shelter/src/pages/volunteers/search/_hooks/useVolunteerSearch.ts
@@ -1,36 +1,42 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import useSearchHeaderStore from 'shared/store/searchHeaderStore';
 
+import { RecruitSearchFilter } from '@/apis/recruitment';
+import useFetchVolunteers from '@/pages/volunteers/hooks/useFetchVolunteers';
+import useIntersect from '@/pages/volunteers/hooks/useIntersection';
+import { useSearchFilter } from '@/pages/volunteers/search/_hooks/useSearchFilter';
 import { useVolunteerSearchFilter } from '@/pages/volunteers/search/_hooks/useVolunteerSearchFilter';
 
-const DUMMY_RECRUITMENT = {
-  recruitmentId: 1,
-  recruitmentTitle: '봉사자를 모집합니다',
-  recruitmentStartTime: '2021-11-08T11:44:30.327959',
-  recruitmentEndTime: '2021-11-08T11:44:30.327959',
-  recruitmentDeadline: '2021-11-08T11:44:30.327959',
-  recruitmentIsClosed: false,
-  recruitmentApplicantCount: 15,
-  recruitmentCapacity: 15,
-};
+const PAGE_SIZE = 10;
 
 export const useVolunteerSearch = () => {
-  const [recruitmentList, setRecruitmentList] = useState<unknown[]>([]);
+  const [searchFilter, setSearchFilter] =
+    useSearchFilter<RecruitSearchFilter>();
 
-  useEffect(() => {
-    setRecruitmentList(Array.from({ length: 10 }, () => DUMMY_RECRUITMENT));
-  }, []);
-
-  const searchAPI = async () => {
-    // TODO: API call
-  };
+  const { volunteerSearchFilter, setVolunteerSearchFilter } =
+    useVolunteerSearchFilter(searchFilter, setSearchFilter);
 
   const {
-    isSearched,
-    setKeywordFilter,
-    volunteerSearchFilter,
-    setVolunteerSearchFilter,
-  } = useVolunteerSearchFilter(searchAPI);
+    data: { pages },
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useFetchVolunteers(PAGE_SIZE, searchFilter);
+
+  const ref = useIntersect(async (entry, observer) => {
+    observer.unobserve(entry.target);
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  });
+
+  useEffect(() => {
+    if (Object.keys(searchFilter).length === 0) {
+      return;
+    }
+
+    fetchNextPage();
+  }, [searchFilter]);
 
   const [setOnSearch, setKeyword] = useSearchHeaderStore((state) => [
     state.setOnSearch,
@@ -38,7 +44,7 @@ export const useVolunteerSearch = () => {
   ]);
 
   useEffect(() => {
-    setOnSearch(setKeywordFilter);
+    setOnSearch((keyword) => setSearchFilter({ keyword }));
 
     return () => {
       setKeyword('');
@@ -47,8 +53,9 @@ export const useVolunteerSearch = () => {
   }, []);
 
   return {
-    isSearched,
-    recruitmentList,
+    ref,
+    isSearched: Boolean(searchFilter.keyword),
+    recruitmentList: pages.flatMap(({ recruitments }) => recruitments),
     volunteerSearchFilter,
     setVolunteerSearchFilter,
   };

--- a/apps/shelter/src/pages/volunteers/search/_hooks/useVolunteerSearchFilter.ts
+++ b/apps/shelter/src/pages/volunteers/search/_hooks/useVolunteerSearchFilter.ts
@@ -1,10 +1,9 @@
 import { ChangeEvent, useEffect, useState } from 'react';
 
-import { useSearchFilter } from '@/pages/volunteers/search/_hooks/useSearchFilter';
+import { RecruitSearchFilter } from '@/apis/recruitment';
 import {
   Category,
   RecruitmentStatus,
-  SearchFilter,
   VolunteerSearchFilter,
 } from '@/pages/volunteers/search/_types/filter';
 import {
@@ -14,17 +13,10 @@ import {
   createVolunteerSearchFilter,
 } from '@/pages/volunteers/search/_utils/createFilter';
 
-export const useVolunteerSearchFilter = (searchAPI: () => void) => {
-  const search = (filter: SearchFilter) => {
-    console.log('filter', filter);
-    // TODO: filter 를 통해 request 객체 가공하기
-    // request = createSearchRequest(filter);
-    // searchAPI(request);
-    searchAPI();
-  };
-
-  const [searchFilter, setSearchFilter] = useSearchFilter<SearchFilter>(search);
-
+export const useVolunteerSearchFilter = (
+  searchFilter: RecruitSearchFilter,
+  setSearchFilter: (filter: RecruitSearchFilter) => void,
+) => {
   const [volunteerSearchFilter, setVolunteerSearchFilter] =
     useState<VolunteerSearchFilter>({} as VolunteerSearchFilter);
 
@@ -47,7 +39,7 @@ export const useVolunteerSearchFilter = (searchAPI: () => void) => {
 
     const newFilter = createPeriodSearchFilter(value);
 
-    setSearchFilter({ ...searchFilter, ...newFilter });
+    setSearchFilter(newFilter);
   };
 
   const setRecruitmentStatus = (event: ChangeEvent<HTMLSelectElement>) => {
@@ -60,7 +52,7 @@ export const useVolunteerSearchFilter = (searchAPI: () => void) => {
 
     const newFilter = createRecruitmentStatusSearchFilter(value);
 
-    setSearchFilter({ ...searchFilter, ...newFilter });
+    setSearchFilter(newFilter);
   };
 
   const setCategory = (event: ChangeEvent<HTMLSelectElement>) => {
@@ -73,16 +65,10 @@ export const useVolunteerSearchFilter = (searchAPI: () => void) => {
 
     const newFilter = createCategorySearchFilter(value);
 
-    setSearchFilter({ ...searchFilter, ...newFilter });
-  };
-
-  const setKeywordFilter = (keyword: string) => {
-    setSearchFilter({ ...searchFilter, keyword });
+    setSearchFilter(newFilter);
   };
 
   return {
-    isSearched: Boolean(searchFilter.keyword),
-    setKeywordFilter,
     volunteerSearchFilter,
     setVolunteerSearchFilter: { setPeriod, setRecruitmentStatus, setCategory },
   };

--- a/apps/shelter/src/pages/volunteers/search/_types/filter.ts
+++ b/apps/shelter/src/pages/volunteers/search/_types/filter.ts
@@ -3,15 +3,6 @@ import {
   RECRUITMENT_STATUS,
 } from '@/pages/volunteers/search/_constants/filter';
 
-export type SearchFilter = Partial<{
-  keyword: string;
-  startDate: string;
-  endDate: string;
-  isClosed: string;
-  content: string;
-  title: string;
-}>;
-
 export type RecruitmentStatus =
   (typeof RECRUITMENT_STATUS)[keyof typeof RECRUITMENT_STATUS];
 

--- a/apps/shelter/src/pages/volunteers/search/_utils/createFilter.ts
+++ b/apps/shelter/src/pages/volunteers/search/_utils/createFilter.ts
@@ -1,15 +1,13 @@
 import { MILISECONDS } from 'shared/constants/date';
 import { createFormattedTime, isSameDay } from 'shared/utils/date';
 
+import { RecruitSearchFilter } from '@/apis/recruitment';
 import {
   CATEGORY,
   PERIOD,
   RECRUITMENT_STATUS,
 } from '@/pages/volunteers/search/_constants/filter';
-import {
-  SearchFilter,
-  VolunteerSearchFilter,
-} from '@/pages/volunteers/search/_types/filter';
+import { VolunteerSearchFilter } from '@/pages/volunteers/search/_types/filter';
 
 const createPeriod = (startDate?: string, endDate?: string) => {
   if (!startDate) {
@@ -41,7 +39,7 @@ const createPeriod = (startDate?: string, endDate?: string) => {
 };
 
 export const createVolunteerSearchFilter = (
-  filter: SearchFilter,
+  filter: RecruitSearchFilter,
 ): VolunteerSearchFilter => {
   const { startDate, endDate, isClosed, title, content } = filter;
 
@@ -53,8 +51,7 @@ export const createVolunteerSearchFilter = (
   }
 
   if (isClosed) {
-    volunteerSearchFilter.recruitmentStatus =
-      isClosed === String(true) ? 'isClosed' : 'isOpen';
+    volunteerSearchFilter.recruitmentStatus = isClosed ? 'isClosed' : 'isOpen';
   }
 
   if (title) {
@@ -68,7 +65,9 @@ export const createVolunteerSearchFilter = (
   return volunteerSearchFilter;
 };
 
-export const createPeriodSearchFilter = (value: string): SearchFilter => {
+export const createPeriodSearchFilter = (
+  value: string,
+): RecruitSearchFilter => {
   if (Object.values(PERIOD).every((period) => period !== value)) {
     return { startDate: undefined, endDate: undefined };
   }
@@ -96,25 +95,27 @@ export const createPeriodSearchFilter = (value: string): SearchFilter => {
 
 export const createRecruitmentStatusSearchFilter = (
   value: string,
-): SearchFilter => {
+): RecruitSearchFilter => {
   if (value === RECRUITMENT_STATUS.IS_CLOSED) {
-    return { isClosed: String(true) };
+    return { isClosed: true };
   }
 
   if (value === RECRUITMENT_STATUS.IS_OPEN) {
-    return { isClosed: String(false) };
+    return { isClosed: false };
   }
 
   return { isClosed: undefined };
 };
 
-export const createCategorySearchFilter = (value: string): SearchFilter => {
+export const createCategorySearchFilter = (
+  value: string,
+): RecruitSearchFilter => {
   if (value === CATEGORY.TITLE) {
-    return { title: String(true), content: undefined };
+    return { title: true, content: undefined };
   }
 
   if (value === CATEGORY.CONTENT) {
-    return { title: undefined, content: String(true) };
+    return { title: undefined, content: true };
   }
 
   return { title: undefined, content: undefined };

--- a/apps/shelter/src/pages/volunteers/search/index.tsx
+++ b/apps/shelter/src/pages/volunteers/search/index.tsx
@@ -1,5 +1,7 @@
 import { Box } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
 
+import { Recruitment } from '@/apis/recruitment';
 import RecruitItem from '@/pages/volunteers/_components/RecruitItem';
 import FilterGroup from '@/pages/volunteers/search/_components/FilterGroup';
 import FilterSelect from '@/pages/volunteers/search/_components/FilterSelect';
@@ -12,6 +14,7 @@ import { useVolunteerSearch } from '@/pages/volunteers/search/_hooks/useVoluntee
 
 export default function VolunteersSearchPage() {
   const {
+    ref,
     isSearched,
     recruitmentList,
     volunteerSearchFilter,
@@ -21,6 +24,23 @@ export default function VolunteersSearchPage() {
   const { period, recruitmentStatus, category } = volunteerSearchFilter;
   const { setPeriod, setRecruitmentStatus, setCategory } =
     setVolunteerSearchFilter;
+
+  const navigate = useNavigate();
+
+  const goToManageApplyPage = (postId: number) => {
+    navigate(`/manage/apply/${postId}`);
+  };
+  const goToManageAttendancePage = (postId: number) => {
+    navigate(`/manage/attendance/${postId}`);
+  };
+  const goToUpdatePage = (postId: number) => {
+    navigate(`/volunteers/write/${postId}`);
+  };
+
+  //TODO 삭제 버튼 눌렀을 때 기능 추가
+
+  //TODO recruit id 받아서 마감
+  const closeRecruit = () => {};
 
   if (!isSearched) {
     return null;
@@ -59,9 +79,21 @@ export default function VolunteersSearchPage() {
           <option value={CATEGORY.CONTENT}>글 내용</option>
         </FilterSelect>
       </FilterGroup>
-      {recruitmentList?.map((recruitmentItem: any) => (
-        <RecruitItem key={recruitmentItem.recruitmentId} {...recruitmentItem} />
+      {recruitmentList?.map((recruitment: Recruitment) => (
+        <RecruitItem
+          key={recruitment.recruitmentId}
+          {...recruitment}
+          onClickManageApplyButton={() =>
+            goToManageApplyPage(recruitment.recruitmentId)
+          }
+          onClickManageAttendanceButton={() =>
+            goToManageAttendancePage(recruitment.recruitmentId)
+          }
+          onClickCloseRecruitButton={closeRecruit}
+          onUpdate={() => goToUpdatePage(recruitment.recruitmentId)}
+        />
       ))}
+      <div ref={ref} />
     </Box>
   );
 }


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #90 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->
- 봉사자 모집 게시글 리스트의 useFetchVolunteers 를 사용하여 구현

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

### 검색 필터 관련 API 이슈
검색 페이지의 필터 디자인과 API request params 상태가 많이 달라서 두 상태를 한 번에 관리하기가 어려운 것 같습니다.


<img width="450" height="150" alt="image" src="https://github.com/Anifriends/Anifriends-Frontend/assets/74397358/09f8a644-706f-4c2d-b9c0-4423b47fb6ea">
<img width="450" height="150" alt="image" src="https://github.com/Anifriends/Anifriends-Frontend/assets/74397358/d03e6338-dc70-4579-8a44-291f1db608cf">


필터 Select Input 의 상태와, url query string 의 상태, 서버에 요청할 search params 세 가지 상태를 동시에 관리하는 것이 불필요한 작업인 것 같다고 생각이 들었습니다.
이에 따라 다음 이슈들을 백엔드 개발자분들께 공유 후, 논의해보아야 할 것 같습니다.

1. 봉사일 검색 필터 이슈
- 봉사일의 시작 날짜와 끝 날짜를 입력받기 위해서는 date picker UI 를 개발해야하지만, 화면 디자인과 개발 일정 상, 수동으로 기간을 입력받는 기능을 추가하기가 어려웠습니다.
- 따라서 1일 이내, 1주 이내, 1개월 이내 등의 option input 으로 기간 검색을 수행할 수 있도록 기능을 먼저 개발했습니다.
- 하지만, url 의 query string 은 startDate 와 endDate 로 되어있어, query string 을 parsing 하여 1일 이내, 1주 이내, 1개월 이내 등의 입력으로 바꿔주는 불필요할 로직이 필요하게 되었습니다.
- 이 문제를 해결하기 위해 봉사일 검색 필터에서 검색 기간을 요청하는 대신 1일 이내, 1주 이내, 1개월 이내 등의 ENUM 으로 요청할 수 있도록 기능 수정을 요쳥해야할 것 같습니다.
- 자세한 기간 검색 옵션은 백엔드와 상의 후 결정해야할 것 같습니다.
```typescript
enum VOLUNTEER_PERIOD = {
  WITHIN_ONE_DAY: '1일 이내',
  WITHIN_ONE_WEEK: '1주 이내',
  WITHIN_ONE_MONTH: '1개월 이내',
  WITHIN_THREE_MONTH: '3개월 이내',
};
```

2. 모집 상태 필터 이슈
- 모집 상태 필터 또한 마찬가지로, 모집 상태를 isClosed 상태 하나로만 두고 있는데, 해당 상태를 Select UI 의 input 과 url query string 에서 동시에 공유하고 있어야 합니다.
- isClosed 는 Boolean 으로 정의되어 있는데, query string 의 value 는 모두 String 타입으로 되어 있어서 둘 사이의 타입 불일치로 인한 버그가 발생합니다.
- 아무 옵션도 선택하지 않은 상태이면, isClosed 는 undefined 상태인데, 이를 false 상태로 파싱하게 되는 버그 발생
- 이 부분 또한 검색 옵션을 Enum 으로 관리하여 해결할 수 있을 것 같습니다.
```typescript
enum RECRUITMENT_STATUS= {
  IS_OPEN: '모집 중',
  IS_CLOSED: '마감 완료',
};
```
3. 검색 옵션 필터 이슈
- title 과 content, 이 두 가지 search params 를 하나의 Select UI 로 관리하면서 생기는 예외사항이 존재합니다.
- 아무 옵션도 선택하지 않은 상태인 경우, title 과 content 옵션을 모두 true 로 준 것과 같은 기능이라고 이해하고 있습니다.
- 이 부분에 대한 예외처리를 하는 것보다 하나의 ENUM 을 통해 옵션을 관리하는 것이 좋을 것 같습니다.
```typescript
enum SEARCH_OPTION= {
  TITLE: '제목',
  CONTENT: '내용',
};
```
