### PR TITLE
refactor: auth 관련 타입 상수명 개선 및 tanstack react query 사용으로 인한 auth api 내부 try catch (error) 제거

### DIFF
--- a/apps/shelter/src/apis/auth.ts
+++ b/apps/shelter/src/apis/auth.ts
@@ -1,68 +1,26 @@
-import type { AxiosResponse } from 'axios';
-import { AxiosError } from 'axios';
 import axiosInstance from 'shared/apis/axiosInstance';
 import type {
-  checkDuplicatedEmailParams,
-  checkDuplicatedEmailResponse,
-  SigninParams,
-  SigninResponse,
+  checkDuplicatedEmailRequestData,
+  checkDuplicatedEmailResponseData,
+  SigninRequestData,
+  SigninResponseData,
 } from 'shared/types/apis/auth';
-import type { ErrorResponse } from 'shared/types/apis/error';
 
-import { SignupParams } from '@/types/apis/auth';
+import { SignupRequestData } from '@/types/apis/auth';
 
-export const signinShelter = async (
-  data: SigninParams,
-): Promise<AxiosResponse<SigninResponse> | AxiosError<ErrorResponse>> => {
-  try {
-    const response = await axiosInstance.post<SigninResponse, SigninParams>(
-      '/auth/shelters/login',
-      data,
-    );
+export const signinShelter = async (data: SigninRequestData) =>
+  await axiosInstance.post<SigninResponseData, SigninRequestData>(
+    '/auth/shelters/login',
+    data,
+  );
 
-    return response;
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      return error;
-    }
+export const signupShelter = async (data: SignupRequestData) =>
+  await axiosInstance.post<unknown, SignupRequestData>('/shelters', data);
 
-    throw error;
-  }
-};
-
-export const signupShelter = async (
-  data: SignupParams,
-): Promise<AxiosError<ErrorResponse> | void> => {
-  try {
-    await axiosInstance.post<unknown, SignupParams>('/shelters', data);
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      return error;
-    }
-
-    throw error;
-  }
-};
-
-export const checkDuplicatedShelterEmail = async (
-  email: string,
-): Promise<
-  AxiosResponse<checkDuplicatedEmailResponse> | AxiosError<ErrorResponse>
-> => {
-  try {
-    const response = axiosInstance.post<
-      checkDuplicatedEmailResponse,
-      checkDuplicatedEmailParams
-    >('/shelters/email', {
-      email,
-    });
-
-    return response;
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      return error;
-    }
-
-    throw error;
-  }
-};
+export const checkDuplicatedShelterEmail = async (email: string) =>
+  await axiosInstance.post<
+    checkDuplicatedEmailResponseData,
+    checkDuplicatedEmailRequestData
+  >('/shelters/email', {
+    email,
+  });

--- a/apps/shelter/src/types/apis/auth.ts
+++ b/apps/shelter/src/types/apis/auth.ts
@@ -1,6 +1,6 @@
-import { SigninParams } from 'shared/types/apis/auth';
+import { SigninRequestData } from 'shared/types/apis/auth';
 
-export type SignupParams = SigninParams & {
+export type SignupRequestData = SigninRequestData & {
   name: string;
   address: string;
   addressDetail: string;

--- a/apps/volunteer/src/apis/auth.ts
+++ b/apps/volunteer/src/apis/auth.ts
@@ -1,68 +1,26 @@
-import type { AxiosResponse } from 'axios';
-import { AxiosError } from 'axios';
 import axiosInstance from 'shared/apis/axiosInstance';
 import type {
-  checkDuplicatedEmailParams,
-  checkDuplicatedEmailResponse,
-  SigninParams,
-  SigninResponse,
+  checkDuplicatedEmailRequestData,
+  checkDuplicatedEmailResponseData,
+  SigninRequestData,
+  SigninResponseData,
 } from 'shared/types/apis/auth';
-import type { ErrorResponse } from 'shared/types/apis/error';
 
-import { SignupParams } from '@/types/apis/auth';
+import { SignupRequestData } from '@/types/apis/auth';
 
-export const signinVolunteer = async (
-  data: SigninParams,
-): Promise<AxiosResponse<SigninResponse> | AxiosError<ErrorResponse>> => {
-  try {
-    const response = await axiosInstance.post<SigninResponse, SigninParams>(
-      '/auth/volunteers/login',
-      data,
-    );
+export const signinVolunteer = async (data: SigninRequestData) =>
+  await axiosInstance.post<SigninResponseData, SigninRequestData>(
+    '/auth/volunteers/login',
+    data,
+  );
 
-    return response;
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      return error;
-    }
+export const signupVolunteer = async (data: SignupRequestData) =>
+  await axiosInstance.post<unknown, SigninRequestData>('/volunteers', data);
 
-    throw error;
-  }
-};
-
-export const signupVolunteer = async (
-  data: SignupParams,
-): Promise<AxiosError<ErrorResponse> | void> => {
-  try {
-    await axiosInstance.post<unknown, SignupParams>('/volunteers', data);
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      return error;
-    }
-
-    throw error;
-  }
-};
-
-export const checkDuplicatedVolunteerEmail = async (
-  email: string,
-): Promise<
-  AxiosResponse<checkDuplicatedEmailResponse> | AxiosError<ErrorResponse>
-> => {
-  try {
-    const response = axiosInstance.post<
-      checkDuplicatedEmailResponse,
-      checkDuplicatedEmailParams
-    >('/volunteers/email', {
-      email,
-    });
-
-    return response;
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      return error;
-    }
-
-    throw error;
-  }
-};
+export const checkDuplicatedVolunteerEmail = async (email: string) =>
+  await axiosInstance.post<
+    checkDuplicatedEmailResponseData,
+    checkDuplicatedEmailRequestData
+  >('/volunteers/email', {
+    email,
+  });

--- a/apps/volunteer/src/types/apis/auth.ts
+++ b/apps/volunteer/src/types/apis/auth.ts
@@ -1,8 +1,8 @@
-import { SigninParams } from 'shared/types/apis/auth';
+import { SigninRequestData } from 'shared/types/apis/auth';
 
 import { PersonGenderEng } from '../gender';
 
-export type SignupParams = SigninParams & {
+export type SignupRequestData = SigninRequestData & {
   name: string;
   birthDate: string;
   phoneNumber: string;

--- a/packages/shared/types/apis/auth.ts
+++ b/packages/shared/types/apis/auth.ts
@@ -1,17 +1,17 @@
-export type checkDuplicatedEmailParams = {
+export type checkDuplicatedEmailRequestData = {
   email: string;
 };
 
-export type SigninParams = checkDuplicatedEmailParams & {
+export type SigninRequestData = checkDuplicatedEmailRequestData & {
   password: string;
 };
 
-export type SigninResponse = {
+export type SigninResponseData = {
   accessToken: string;
   useId: number;
   role: string;
 };
 
-export type checkDuplicatedEmailResponse = {
+export type checkDuplicatedEmailResponseData = {
   isDuplicated: boolean;
 };

--- a/packages/shared/types/apis/error.ts
+++ b/packages/shared/types/apis/error.ts
@@ -1,4 +1,4 @@
-export type ErrorResponse = {
+export type ErrorResponseData = {
   errorCode: string;
   message: string;
 };


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #117 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->

* [refactor(shared): error 관련 response data type명 명확하게 변경](https://github.com/Anifriends/Anifriends-Frontend/commit/e1181561b2a0ee3f314b6ffa8b5813bcf115bfad)
* [refactor(shared, shelter, volunteer): auth 관련 type명 명확하게 변경](https://github.com/Anifriends/Anifriends-Frontend/commit/262f1c2f4e84d04604b405803f9cb8ef5e5ada09)
* [refactor(shelter, volunteer): auth 관련 api 함수들에서 error 제거](https://github.com/Anifriends/Anifriends-Frontend/commit/3084089a8b1beafe5ffc750d3fe09aa4c6a9c472)

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

Params를 RequestData로 바꾸고, Response를 ResponseData로 바꿨습니다!!
tanstack query의 onError 기능을 활용하기 위해 try catch (error) 문을 없앴습니다!