### PR TITLE
feat: 보호소앱과 봉사자앱의 회원가입 페이지의 msw 연동 및 관련 로직 추가

### DIFF
--- a/apps/shelter/src/apis/auth.ts
+++ b/apps/shelter/src/apis/auth.ts
@@ -1,7 +1,7 @@
 import axiosInstance from 'shared/apis/axiosInstance';
 import type {
-  checkDuplicatedEmailRequestData,
-  checkDuplicatedEmailResponseData,
+  CheckDuplicatedEmailRequestData,
+  CheckDuplicatedEmailResponseData,
   SigninRequestData,
   SigninResponseData,
 } from 'shared/types/apis/auth';
@@ -17,10 +17,10 @@ export const signinShelter = async (data: SigninRequestData) =>
 export const signupShelter = async (data: SignupRequestData) =>
   await axiosInstance.post<unknown, SignupRequestData>('/shelters', data);
 
-export const checkDuplicatedShelterEmail = async (email: string) =>
+export const checkDuplicatedShelterEmail = async (
+  data: CheckDuplicatedEmailRequestData,
+) =>
   await axiosInstance.post<
-    checkDuplicatedEmailResponseData,
-    checkDuplicatedEmailRequestData
-  >('/shelters/email', {
-    email,
-  });
+    CheckDuplicatedEmailResponseData,
+    CheckDuplicatedEmailRequestData
+  >('/shelters/email', data);

--- a/apps/volunteer/src/apis/auth.ts
+++ b/apps/volunteer/src/apis/auth.ts
@@ -1,7 +1,7 @@
 import axiosInstance from 'shared/apis/axiosInstance';
 import type {
-  checkDuplicatedEmailRequestData,
-  checkDuplicatedEmailResponseData,
+  CheckDuplicatedEmailRequestData,
+  CheckDuplicatedEmailResponseData,
   SigninRequestData,
   SigninResponseData,
 } from 'shared/types/apis/auth';
@@ -17,10 +17,10 @@ export const signinVolunteer = async (data: SigninRequestData) =>
 export const signupVolunteer = async (data: SignupRequestData) =>
   await axiosInstance.post<unknown, SigninRequestData>('/volunteers', data);
 
-export const checkDuplicatedVolunteerEmail = async (email: string) =>
+export const checkDuplicatedVolunteerEmail = async (
+  data: CheckDuplicatedEmailRequestData,
+) =>
   await axiosInstance.post<
-    checkDuplicatedEmailResponseData,
-    checkDuplicatedEmailRequestData
-  >('/volunteers/email', {
-    email,
-  });
+    CheckDuplicatedEmailResponseData,
+    CheckDuplicatedEmailRequestData
+  >('/volunteers/email', data);

--- a/apps/volunteer/src/pages/signup/index.tsx
+++ b/apps/volunteer/src/pages/signup/index.tsx
@@ -387,7 +387,7 @@ export default function SignupPage() {
               bg: undefined,
             }}
           >
-            로그인
+            회원가입
           </Button>
           <Button
             fontWeight="semibold"
@@ -401,8 +401,9 @@ export default function SignupPage() {
             _active={{
               bg: undefined,
             }}
+            onClick={goSigninPage}
           >
-            회원가입
+            로그인
           </Button>
           <Button
             fontWeight="semibold"

--- a/packages/shared/types/apis/auth.ts
+++ b/packages/shared/types/apis/auth.ts
@@ -1,8 +1,8 @@
-export type checkDuplicatedEmailRequestData = {
+export type CheckDuplicatedEmailRequestData = {
   email: string;
 };
 
-export type SigninRequestData = checkDuplicatedEmailRequestData & {
+export type SigninRequestData = CheckDuplicatedEmailRequestData & {
   password: string;
 };
 
@@ -12,6 +12,6 @@ export type SigninResponseData = {
   role: string;
 };
 
-export type checkDuplicatedEmailResponseData = {
+export type CheckDuplicatedEmailResponseData = {
   isDuplicated: boolean;
 };


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #101 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->

* [refactor(shared): 이메일 인증 관련 타입명 변경](https://github.com/Anifriends/Anifriends-Frontend/commit/b5fa355086c6a9f60f9f47f1013b10309184fc4f)
* [refactor(shelter, volunteer): 이메일 인증 관련 변경된 타입명으로 수정](https://github.com/Anifriends/Anifriends-Frontend/commit/c6d2045fa7642f89b6d56739ee9528ed06780258)
* [feat(shelter, volunteer): SignupPage 컴포넌트 msw 관련 로직 추가](https://github.com/Anifriends/Anifriends-Frontend/commit/74e83dcc46fef2503f450082842190fa851124b6)
* [feat(volunteer): SignupPage의 로그인 버튼에 로그인 화면으로 이동하는 로직 추가](https://github.com/Anifriends/Anifriends-Frontend/commit/5d8a559fc186176dc85288734c34743738f5b8c5)

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
