### PR TITLE
refactor: @tanstack/react-query의 기본 Error 타입 AxiosError로 변경

### DIFF
--- a/apps/shelter/src/pages/signin/index.tsx
+++ b/apps/shelter/src/pages/signin/index.tsx
@@ -15,8 +15,6 @@ import {
 } from '@chakra-ui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
-import type { AxiosResponse } from 'axios';
-import { AxiosError } from 'axios';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -24,11 +22,7 @@ import AnimalfriendsLogo from 'shared/assets/image-anifriends-logo.png';
 import IoEyeOff from 'shared/assets/IoEyeOff';
 import IoEyeSharp from 'shared/assets/IoEyeSharp';
 import useToggle from 'shared/hooks/useToggle';
-import type {
-  SigninRequestData,
-  SigninResponseData,
-} from 'shared/types/apis/auth';
-import { ErrorResponseData } from 'shared/types/apis/error';
+import { SigninRequestData } from 'shared/types/apis/auth';
 import * as z from 'zod';
 
 import { signinShelter } from '@/apis/auth';
@@ -56,12 +50,8 @@ export default function SigninPage() {
   } = useForm<Schema>({
     resolver: zodResolver(schema),
   });
-  const { mutate } = useMutation<
-    AxiosResponse<SigninResponseData>,
-    AxiosError<ErrorResponseData>,
-    SigninRequestData
-  >({
-    mutationFn: (data) => signinShelter(data),
+  const { mutate } = useMutation({
+    mutationFn: (data: SigninRequestData) => signinShelter(data),
     onSuccess: () => {
       navigate(`/${PATH.VOLUNTEERS.INDEX}`);
     },

--- a/apps/shelter/src/pages/signup/index.tsx
+++ b/apps/shelter/src/pages/signup/index.tsx
@@ -19,19 +19,13 @@ import {
 } from '@chakra-ui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
-import type { AxiosResponse } from 'axios';
-import { AxiosError } from 'axios';
 import { Controller, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import AnimalfriendsLogo from 'shared/assets/image-anifriends-logo.png';
 import IoEyeOff from 'shared/assets/IoEyeOff';
 import IoEyeSharp from 'shared/assets/IoEyeSharp';
 import useToggle from 'shared/hooks/useToggle';
-import {
-  CheckDuplicatedEmailRequestData,
-  CheckDuplicatedEmailResponseData,
-} from 'shared/types/apis/auth';
-import { ErrorResponseData } from 'shared/types/apis/error';
+import { CheckDuplicatedEmailRequestData } from 'shared/types/apis/auth';
 import * as z from 'zod';
 
 import { checkDuplicatedShelterEmail, signupShelter } from '@/apis/auth';
@@ -104,12 +98,8 @@ export default function SignupPage() {
   });
   const watchIsEmailDuplicated = watch('isEmailDuplicated');
   const watchEmail = watch('email');
-  const { mutate: signupShelterMutate } = useMutation<
-    AxiosResponse<unknown>,
-    AxiosError<ErrorResponseData>,
-    SignupRequestData
-  >({
-    mutationFn: (data) => signupShelter(data),
+  const { mutate: signupShelterMutate } = useMutation({
+    mutationFn: (data: SignupRequestData) => signupShelter(data),
     onSuccess: () => {
       toast({
         position: 'top',
@@ -129,12 +119,9 @@ export default function SignupPage() {
       });
     },
   });
-  const { mutate: checkDuplicatedEmailMutate } = useMutation<
-    AxiosResponse<CheckDuplicatedEmailResponseData>,
-    AxiosError<ErrorResponseData>,
-    CheckDuplicatedEmailRequestData
-  >({
-    mutationFn: (data) => checkDuplicatedShelterEmail(data),
+  const { mutate: checkDuplicatedEmailMutate } = useMutation({
+    mutationFn: (data: CheckDuplicatedEmailRequestData) =>
+      checkDuplicatedShelterEmail(data),
     onSuccess: ({ data: { isDuplicated } }) => {
       if (isDuplicated) {
         setValue('isEmailDuplicated', true);

--- a/apps/shelter/src/react-query.d.ts
+++ b/apps/shelter/src/react-query.d.ts
@@ -1,0 +1,10 @@
+import '@tanstack/react-query';
+
+import { AxiosError } from 'axios';
+import { ErrorResponseData } from 'shared/types/apis/error';
+
+declare module '@tanstack/react-query' {
+  interface Register {
+    defaultError: AxiosError<ErrorResponseData>;
+  }
+}

--- a/apps/volunteer/src/pages/signin/index.tsx
+++ b/apps/volunteer/src/pages/signin/index.tsx
@@ -15,8 +15,6 @@ import {
 } from '@chakra-ui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
-import type { AxiosResponse } from 'axios';
-import { AxiosError } from 'axios';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -24,11 +22,7 @@ import AnimalfriendsLogo from 'shared/assets/image-anifriends-logo.png';
 import IoEyeOff from 'shared/assets/IoEyeOff';
 import IoEyeSharp from 'shared/assets/IoEyeSharp';
 import useToggle from 'shared/hooks/useToggle';
-import type {
-  SigninRequestData,
-  SigninResponseData,
-} from 'shared/types/apis/auth';
-import { ErrorResponseData } from 'shared/types/apis/error';
+import { SigninRequestData } from 'shared/types/apis/auth';
 import * as z from 'zod';
 
 import { signinVolunteer } from '@/apis/auth';
@@ -56,12 +50,8 @@ export default function SigninPage() {
   } = useForm<Schema>({
     resolver: zodResolver(schema),
   });
-  const { mutate } = useMutation<
-    AxiosResponse<SigninResponseData>,
-    AxiosError<ErrorResponseData>,
-    SigninRequestData
-  >({
-    mutationFn: (data) => signinVolunteer(data),
+  const { mutate } = useMutation({
+    mutationFn: (data: SigninRequestData) => signinVolunteer(data),
     onSuccess: () => {
       navigate(`/${PATH.VOLUNTEERS.INDEX}`);
     },

--- a/apps/volunteer/src/pages/signup/index.tsx
+++ b/apps/volunteer/src/pages/signup/index.tsx
@@ -17,8 +17,6 @@ import {
 } from '@chakra-ui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
-import type { AxiosResponse } from 'axios';
-import { AxiosError } from 'axios';
 import { Controller, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import AnimalfriendsLogo from 'shared/assets/image-anifriends-logo.png';
@@ -26,11 +24,7 @@ import IoEyeOff from 'shared/assets/IoEyeOff';
 import IoEyeSharp from 'shared/assets/IoEyeSharp';
 import RadioGroup from 'shared/components/RadioGroup';
 import useToggle from 'shared/hooks/useToggle';
-import {
-  CheckDuplicatedEmailRequestData,
-  CheckDuplicatedEmailResponseData,
-} from 'shared/types/apis/auth';
-import { ErrorResponseData } from 'shared/types/apis/error';
+import { CheckDuplicatedEmailRequestData } from 'shared/types/apis/auth';
 import * as z from 'zod';
 
 import { checkDuplicatedVolunteerEmail, signupVolunteer } from '@/apis/auth';
@@ -106,12 +100,8 @@ export default function SignupPage() {
   });
   const watchIsEmailDuplicated = watch('isEmailDuplicated');
   const watchEmail = watch('email');
-  const { mutate: signupVolunteerMutate } = useMutation<
-    AxiosResponse<unknown>,
-    AxiosError<ErrorResponseData>,
-    SignupRequestData
-  >({
-    mutationFn: (data) => signupVolunteer(data),
+  const { mutate: signupVolunteerMutate } = useMutation({
+    mutationFn: (data: SignupRequestData) => signupVolunteer(data),
     onSuccess: () => {
       toast({
         position: 'top',
@@ -131,12 +121,9 @@ export default function SignupPage() {
       });
     },
   });
-  const { mutate: checkDuplicatedEmailMutate } = useMutation<
-    AxiosResponse<CheckDuplicatedEmailResponseData>,
-    AxiosError<ErrorResponseData>,
-    CheckDuplicatedEmailRequestData
-  >({
-    mutationFn: (data) => checkDuplicatedVolunteerEmail(data),
+  const { mutate: checkDuplicatedEmailMutate } = useMutation({
+    mutationFn: (data: CheckDuplicatedEmailRequestData) =>
+      checkDuplicatedVolunteerEmail(data),
     onSuccess: ({ data: { isDuplicated } }) => {
       if (isDuplicated) {
         setValue('isEmailDuplicated', true);

--- a/apps/volunteer/src/react-query.d.ts
+++ b/apps/volunteer/src/react-query.d.ts
@@ -1,0 +1,10 @@
+import '@tanstack/react-query';
+
+import { AxiosError } from 'axios';
+import { ErrorResponseData } from 'shared/types/apis/error';
+
+declare module '@tanstack/react-query' {
+  interface Register {
+    defaultError: AxiosError<ErrorResponseData>;
+  }
+}


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #127 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->

* [feat(shelter, volunteer): AxiosError 내용이 담긴 react-query.d.ts 추가](https://github.com/Anifriends/Anifriends-Frontend/commit/248d16cfa70537510050bb17b7381395e90b71c2)
* [refactor(shelter, volunteer): Signin, Signup의 useMutation의 generics 제거](https://github.com/Anifriends/Anifriends-Frontend/commit/665a2dbd1f9c25ae22df18555239e48ddd8adff1)

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
