### PR TITLE
feat: Local ErrorBoundary 및 Global ErrorBoundary 추가

### DIFF
--- a/packages/shared/apis/axiosInterceptor.ts
+++ b/packages/shared/apis/axiosInterceptor.ts
@@ -5,7 +5,7 @@ import useAuthStore from '../store/authStore';
 export const onRequest = (config: InternalAxiosRequestConfig) => {
   const accessToken = useAuthStore.getState().user?.accessToken;
   if (useAuthStore.getState().user?.accessToken) {
-    config.headers.Authorization = `bearer ${accessToken}`;
+    config.headers.Authorization = `Bearer ${accessToken}`;
   }
   return config;
 };

--- a/packages/shared/apis/axiosInterceptor.ts
+++ b/packages/shared/apis/axiosInterceptor.ts
@@ -2,11 +2,11 @@ import { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 import useAuthStore from '../store/authStore';
 
-const getAccessToken = () =>
-  `bearer ${useAuthStore.getState().user?.accessToken}`;
-
 export const onRequest = (config: InternalAxiosRequestConfig) => {
-  config.headers.Authorization = getAccessToken();
+  const accessToken = useAuthStore.getState().user?.accessToken;
+  if (useAuthStore.getState().user?.accessToken) {
+    config.headers.Authorization = `bearer ${accessToken}`;
+  }
   return config;
 };
 

--- a/packages/shared/components/LocalErrorBoundary.tsx
+++ b/packages/shared/components/LocalErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import { Button, Heading, Text, VStack } from '@chakra-ui/react';
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
+
+const RetryErrorFallback = ({ resetErrorBoundary }: FallbackProps) => {
+  return (
+    <VStack justifyContent="center" alignItems="center" h="full" spacing="4">
+      <Heading as="h4" fontSize="lg" fontWeight="bold">
+        잠시 연결이 늦어지고 있습니다.
+      </Heading>
+      <Text color="gray.400">다시 한번 시도해 주세요</Text>
+      <Button onClick={resetErrorBoundary}>다시 시도</Button>
+    </VStack>
+  );
+};
+
+const FallbackComponent = (props: FallbackProps) => {
+  // 만약 api erro가 발생하면 throw props.error
+
+  return <RetryErrorFallback {...props} />;
+};
+
+export default function LocalErrorBoundary({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <ErrorBoundary FallbackComponent={FallbackComponent}>
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/packages/shared/components/LocalErrorBoundary.tsx
+++ b/packages/shared/components/LocalErrorBoundary.tsx
@@ -5,7 +5,7 @@ const RetryErrorFallback = ({ resetErrorBoundary }: FallbackProps) => {
   return (
     <VStack justifyContent="center" alignItems="center" h="full" spacing="4">
       <Heading as="h4" fontSize="lg" fontWeight="bold">
-        잠시 연결이 늦어지고 있습니다.
+        잠시 연결이 늦어지고 있습니다
       </Heading>
       <Text color="gray.400">다시 한번 시도해 주세요</Text>
       <Button onClick={resetErrorBoundary}>다시 시도</Button>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,7 @@
     "framer-motion": "^10.16.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.11",
     "react-router-dom": "^6.17.0",
     "zustand": "^4.4.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      react-error-boundary:
+        specifier: ^4.0.11
+        version: 4.0.11(react@18.2.0)
       react-router-dom:
         specifier: ^6.17.0
         version: 6.18.0(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #187

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->
- LocalErrorBoundary 컴포넌트를 만들었습니다.
- 유효한 토큰이 있을때만 헤더에 유효한 정보를 넣도록 구현했습니다.

- 예시 사용법

```tsx
import 'shared/components/LocalErrorBoundary'

export default function VolunteersPage() {
  return (
    <LocalErrorBoundary>
      <Suspense fallback={<p>글목록 로딩중...</p>}>
        <Recruitments />
      </Suspense>
    </LocalErrorBoundary>
  );
}

```

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
<img width="458" alt="local ErrorBoundary fallback" src="https://github.com/Anifriends/Anifriends-Frontend/assets/43432783/473b8dc6-c493-435e-bf3f-13fe136640e8">

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 토큰이 만료됐을때의 예외를 처리하는 Global ErrorBoundary도 만들려고 했는데 아직 인증과 관련된 api들이 완전하지 않은 것 같아 나중에 구현해야 할 것 같습니다.
