### PR TITLE
refactor: 공통화로 묶은 zod validation로 기존 페이지들(Signin, Sigup, SettingsPassword) 변경

### DIFF
--- a/apps/shelter/src/pages/settings/password/index.tsx
+++ b/apps/shelter/src/pages/settings/password/index.tsx
@@ -19,6 +19,11 @@ import IoEyeSharp from 'shared/assets/IoEyeSharp';
 import LogoImageBox from 'shared/components/LogoImageBox';
 import useToggle from 'shared/hooks/useToggle';
 import { ChangePasswordRequestData } from 'shared/types/apis/auth';
+import {
+  newPassword,
+  newPasswordConfirm,
+  oldPassword,
+} from 'shared/utils/validations';
 import * as z from 'zod';
 
 import { changeShelterPassword } from '@/apis/auth';
@@ -27,17 +32,9 @@ type Schema = z.infer<typeof schema>;
 
 const schema = z
   .object({
-    oldPassword: z.string().min(1, '기본 비밀번호 정보는 필수입니다'),
-    newPassword: z.string().min(1, '변경 비밀번호 정보는 필수입니다'),
-    // TODO
-    //
-    // .regex(
-    //   /^(?=.*[!@#$%^&*()\-_=+[\]\\|{};:'",<.>/?]+)(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}$/,
-    //   '비밀번호는 필수 정보입니다(8자 이상)',
-    // ),
-    newPasswordConfirm: z
-      .string()
-      .min(1, '변경 비밀번호 확인 정보는 필수입니다'),
+    oldPassword,
+    newPassword,
+    newPasswordConfirm,
   })
   .refine(
     ({ newPassword, newPasswordConfirm }) => newPassword === newPasswordConfirm,

--- a/apps/shelter/src/pages/signin/index.tsx
+++ b/apps/shelter/src/pages/signin/index.tsx
@@ -24,6 +24,7 @@ import IoEyeSharp from 'shared/assets/IoEyeSharp';
 import useToggle from 'shared/hooks/useToggle';
 import useAuthStore from 'shared/store/authStore';
 import { SigninRequestData } from 'shared/types/apis/auth';
+import { email, password } from 'shared/utils/validations';
 import * as z from 'zod';
 
 import { signinShelter } from '@/apis/auth';
@@ -32,11 +33,8 @@ import PATH from '@/constants/path';
 type Schema = z.infer<typeof schema>;
 
 const schema = z.object({
-  email: z
-    .string()
-    .min(1, '이메일이 입려되지 않았습니다')
-    .email('유효하지 않은 이메일입니다'),
-  password: z.string().min(1, '비밀번호가 입력되지 않았습니다'),
+  email,
+  password,
 });
 
 export default function SigninPage() {

--- a/apps/shelter/src/pages/signup/index.tsx
+++ b/apps/shelter/src/pages/signup/index.tsx
@@ -26,6 +26,18 @@ import IoEyeOff from 'shared/assets/IoEyeOff';
 import IoEyeSharp from 'shared/assets/IoEyeSharp';
 import useToggle from 'shared/hooks/useToggle';
 import { CheckDuplicatedEmailRequestData } from 'shared/types/apis/auth';
+import {
+  address,
+  addressDetail,
+  email,
+  isEmailDuplicated,
+  isOpenedAddress,
+  name,
+  password,
+  passwordConfirm,
+  phoneNumber,
+  sparePhoneNumber,
+} from 'shared/utils/validations';
 import * as z from 'zod';
 
 import { checkDuplicatedShelterEmail, signupShelter } from '@/apis/auth';
@@ -36,43 +48,20 @@ type Schema = z.infer<typeof schema>;
 
 const schema = z
   .object({
-    email: z
-      .string()
-      .min(1, '이메일은 필수 정보입니다')
-      .regex(
-        /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
-        '이메일 형식에 맞게 적어주세요',
-      ),
-    isEmailDuplicated: z.boolean(),
-    password: z.string().min(1, '비밀번호는 필수 정보입니다'),
-    // TODO 나중에 추가 예정
-    //
-    // .regex(
-    //   /^(?=.*[!@#$%^&*()\-_=+[\]\\|{};:'",<.>/?]+)(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}$/,
-    //   '비밀번호는 필수 정보입니다(8자 이상)',
-    // ),
-    passwordConfirm: z.string().min(1, '비밀번호 확인 정보는 필수입니다'),
-    name: z.string().min(1, '보호소 이름 정보는 필수입니다'),
-    address: z.string().min(1, '보호소 주소 정보는 필수입니다'),
-    addressDetail: z.string().min(1, '보호소 상세주소 정보는 필수입니다'),
-    isOpenedAddress: z.boolean(),
-    phoneNumber: z
-      .string()
-      .min(1, '보호소 전화번호 정보는 필수입니다')
-      .refine(
-        (val) => !Number.isNaN(Number(val)),
-        '전화번호 형식은 숫자입니다',
-      ),
-    sparePhoneNumber: z
-      .string()
-      .refine(
-        (val) => !Number.isNaN(Number(val)) || val === '',
-        '전화번호 형식은 숫자입니다',
-      ),
+    email,
+    isEmailDuplicated,
+    password,
+    passwordConfirm,
+    name,
+    address,
+    addressDetail,
+    isOpenedAddress,
+    phoneNumber,
+    sparePhoneNumber,
   })
   .refine(({ password, passwordConfirm }) => password === passwordConfirm, {
-    message: '비밀번호가 일치하지 않습니다',
     path: ['passwordConfirm'],
+    message: '비밀번호가 일치하지 않습니다',
   });
 
 export default function SignupPage() {

--- a/apps/volunteer/src/pages/settings/password/index.tsx
+++ b/apps/volunteer/src/pages/settings/password/index.tsx
@@ -19,6 +19,11 @@ import IoEyeSharp from 'shared/assets/IoEyeSharp';
 import LogoImageBox from 'shared/components/LogoImageBox';
 import useToggle from 'shared/hooks/useToggle';
 import { ChangePasswordRequestData } from 'shared/types/apis/auth';
+import {
+  newPassword,
+  newPasswordConfirm,
+  oldPassword,
+} from 'shared/utils/validations';
 import * as z from 'zod';
 
 import { changeVolunteerPassword } from '@/apis/auth';
@@ -27,17 +32,9 @@ type Schema = z.infer<typeof schema>;
 
 const schema = z
   .object({
-    oldPassword: z.string().min(1, '기본 비밀번호 정보는 필수입니다'),
-    newPassword: z.string().min(1, '변경 비밀번호 정보는 필수입니다'),
-    // TODO
-    //
-    // .regex(
-    //   /^(?=.*[!@#$%^&*()\-_=+[\]\\|{};:'",<.>/?]+)(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}$/,
-    //   '비밀번호는 필수 정보입니다(8자 이상)',
-    // ),
-    newPasswordConfirm: z
-      .string()
-      .min(1, '변경 비밀번호 확인 정보는 필수입니다'),
+    oldPassword,
+    newPassword,
+    newPasswordConfirm,
   })
   .refine(
     ({ newPassword, newPasswordConfirm }) => newPassword === newPasswordConfirm,

--- a/apps/volunteer/src/pages/signin/index.tsx
+++ b/apps/volunteer/src/pages/signin/index.tsx
@@ -24,6 +24,7 @@ import IoEyeSharp from 'shared/assets/IoEyeSharp';
 import useToggle from 'shared/hooks/useToggle';
 import useAuthStore from 'shared/store/authStore';
 import { SigninRequestData } from 'shared/types/apis/auth';
+import { email, password } from 'shared/utils/validations';
 import * as z from 'zod';
 
 import { signinVolunteer } from '@/apis/auth';
@@ -32,11 +33,8 @@ import PATH from '@/constants/path';
 type Schema = z.infer<typeof schema>;
 
 const schema = z.object({
-  email: z
-    .string()
-    .min(1, '이메일이 입려되지 않았습니다')
-    .email('유효하지 않은 이메일입니다'),
-  password: z.string().min(1, '비밀번호가 입력되지 않았습니다'),
+  email,
+  password,
 });
 
 export default function SigninPage() {

--- a/apps/volunteer/src/pages/signup/index.tsx
+++ b/apps/volunteer/src/pages/signup/index.tsx
@@ -26,6 +26,16 @@ import RadioGroup from 'shared/components/RadioGroup';
 import useToggle from 'shared/hooks/useToggle';
 import { CheckDuplicatedEmailRequestData } from 'shared/types/apis/auth';
 import { PersonGenderEng, PersonGenderKor } from 'shared/types/gender';
+import {
+  birthDate,
+  email,
+  gender,
+  isEmailDuplicated,
+  name,
+  password,
+  passwordConfirm,
+  phoneNumber,
+} from 'shared/utils/validations';
 import * as z from 'zod';
 
 import { checkDuplicatedVolunteerEmail, signupVolunteer } from '@/apis/auth';
@@ -36,46 +46,18 @@ type Schema = z.infer<typeof schema>;
 
 const schema = z
   .object({
-    email: z
-      .string()
-      .min(1, '이메일은 필수 정보입니다')
-      .regex(
-        /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
-        '이메일 형식에 맞게 적어주세요',
-      ),
-    isEmailDuplicated: z.boolean(),
-    password: z.string(),
-    // TODO 나중에 추가 예정
-    //
-    // .regex(
-    //   /^(?=.*[!@#$%^&*()\-_=+[\]\\|{};:'",<.>/?]+)(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}$/,
-    //   '비밀번호는 필수 정보입니다(8자 이상)',
-    // ),
-    passwordConfirm: z.string().min(1, '비밀번호 확인 정보는 필수입니다'),
-    name: z.string().min(1, '이름 정보는 필수입니다'),
-    birthDate: z
-      .string()
-      .min(1, '생년월일 정보는 필수입니다')
-      .refine(
-        (val) => new Date(val) < new Date(),
-        `${new Date()
-          .toLocaleDateString('ko-KR')
-          .split('')
-          .filter((v) => v !== ' ')
-          .join('')} 이전으로 선택해주세요`,
-      ),
-    phoneNumber: z
-      .string()
-      .min(1, '전화번호 정보는 필수입니다')
-      .refine(
-        (val) => !Number.isNaN(Number(val)),
-        '전화번호 형식은 숫자입니다',
-      ),
-    gender: z.enum(['FEMALE', 'MALE']),
+    email,
+    isEmailDuplicated,
+    password,
+    passwordConfirm,
+    name,
+    birthDate,
+    phoneNumber,
+    gender,
   })
   .refine(({ password, passwordConfirm }) => password === passwordConfirm, {
-    message: '비밀번호가 일치하지 않습니다',
     path: ['passwordConfirm'],
+    message: '비밀번호가 일치하지 않습니다',
   });
 
 export default function SignupPage() {

--- a/packages/shared/utils/validations.ts
+++ b/packages/shared/utils/validations.ts
@@ -20,7 +20,7 @@ export const password = z.string().min(1, '비밀번호 정보는 필수입니�
 export const passwordConfirm = z
   .string()
   .min(1, '비밀번호 확인 정보는 필수입니다');
-export const oldPassword = z.string().min(1, '기본 비밀번호 정보는 필수입니다');
+export const oldPassword = z.string().min(1, '기존 비밀번호 정보는 필수입니다');
 export const newPassword = z.string().min(1, '변경 비밀번호 정보는 필수입니다');
 // TODO 나중에 추가 예정
 //


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #207 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->

* [refactor(shelter, volunteer): signin 페이지의 zod를 공통화된 validations으로 변경](https://github.com/Anifriends/Anifriends-Frontend/commit/0a24bc771d5ab9ad66234e6676eb59465535e007)
* [refactor(shelter, volunteer): signup 페이지의 zod를 공통화된 validations으로 변경](https://github.com/Anifriends/Anifriends-Frontend/commit/2d05370f38f759fb6b5bdb35f446604ffb5df6fc)
* [refactor(shelter, volunteer): SettingsPassword 페이지의 zod를 공통화된 validations으로 변경](https://github.com/Anifriends/Anifriends-Frontend/commit/a0475f49ec94f8185bfe221fe427593ca9b2cfff) 
* [fix(shared): validations의 oldPassword 항목 오타 수정](https://github.com/Anifriends/Anifriends-Frontend/commit/0b4ee6e9d1d5091edd19279645ec8b8b695d2c4b)

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
