### PR TITLE
feat: 봉사모집 상세조회 useQuery  hook  리팩토링

### DIFF
--- a/apps/shelter/src/pages/volunteers/detail/_hooks/useGetVolunteerDetail.ts
+++ b/apps/shelter/src/pages/volunteers/detail/_hooks/useGetVolunteerDetail.ts
@@ -1,57 +1,59 @@
 import { useQuery } from '@tanstack/react-query';
-import { getRecruitmentDetail } from 'shared/apis/common/Recruitments';
 import {
-  createFormattedTime,
-  createWeekDayLocalString,
-} from 'shared/utils/date';
+  getRecruitmentDetail,
+  RecruitmentDetailResponse,
+} from 'shared/apis/common/Recruitments';
 
-const useGetVolunteerDetail = (recruitmentId: number) => {
-  return useQuery({
-    queryKey: ['recruitment', recruitmentId],
-    queryFn: async () => (await getRecruitmentDetail(recruitmentId)).data,
-    select: (data) => {
-      const startDate = new Date(data.recruitmentStartTime);
-      const endDate = new Date(data.recruitmentEndTime);
-      const deadLine = new Date(data.recruitmentDeadline);
+const createRecruitmentDetail = (recruitment: RecruitmentDetailResponse) => {
+  const {
+    recruitmentTitle: title,
+    recruitmentContent: content,
+    recruitmentApplicantCount: applicant,
+    recruitmentCapacity: capacity,
+    recruitmentStartTime: startTime,
+    recruitmentEndTime: endTime,
+    recruitmentDeadline: deadline,
+    recruitmentCreatedAt: createdAt,
+    recruitmentUpdatedAt: updatedAt,
+    recruitmentImageUrls: imageUrls,
+    recruitmentIsClosed: isClosed,
+  } = recruitment;
 
-      return {
-        imageUrls: data.recruitmentImageUrls,
-        title: data.recruitmentTitle,
-        content: data.recruitmentContent,
-        applicant: data.recruitmentApplicantCount,
-        capacity: data.recruitmentCapacity,
-        volunteerDay: `${createFormattedTime(
-          startDate,
-        )}(${createWeekDayLocalString(startDate)})`,
-        recruitmentDeadline: `${createFormattedTime(
-          deadLine,
-        )}(${createWeekDayLocalString(deadLine)}) ${createFormattedTime(
-          deadLine,
-          'hh:mm',
-        )}`,
-        volunteerStartTime: createFormattedTime(startDate, 'hh:mm'),
-        volunteerEndTime: createFormattedTime(endDate, 'hh:mm'),
-        recruitmentCreatedAt: createFormattedTime(
-          new Date(data.recruitmentCreatedAt),
-        ),
-        recruitmentIsClosed: data.recruitmentIsClosed,
-      };
+  return {
+    title,
+    content,
+    applicant,
+    capacity,
+    startTime,
+    endTime,
+    deadline,
+    createdAt,
+    updatedAt,
+    imageUrls,
+    isClosed,
+  };
+};
+
+const useGetVolunteerDetail = (recruitmentId: number) =>
+  useQuery({
+    queryKey: ['recruitment', 'detail', recruitmentId],
+    queryFn: async () => {
+      const response = (await getRecruitmentDetail(recruitmentId)).data;
+      return createRecruitmentDetail(response);
     },
     initialData: {
-      recruitmentTitle: '',
-      recruitmentApplicantCount: 0,
-      recruitmentCapacity: 0,
-      recruitmentContent: '',
-      recruitmentStartTime: '',
-      recruitmentEndTime: '',
-      recruitmentIsClosed: false,
-      recruitmentDeadline: '',
-      recruitmentCreatedAt: '',
-      recruitmentUpdatedAt: '',
-      recruitmentImageUrls: [],
-      shelterId: 0,
+      title: '',
+      content: '',
+      applicant: 0,
+      capacity: 0,
+      startTime: '',
+      endTime: '',
+      deadline: '',
+      createdAt: '',
+      updatedAt: '',
+      imageUrls: [],
+      isClosed: false,
     },
   });
-};
 
 export default useGetVolunteerDetail;

--- a/apps/shelter/src/pages/volunteers/update/index.tsx
+++ b/apps/shelter/src/pages/volunteers/update/index.tsx
@@ -117,9 +117,9 @@ export default function VolunteersUpdatePage() {
 
   useEffect(() => {
     setValue('title', recruitment.title);
-    setValue('startTime', new Date(recruitment.volunteerStartTime));
-    setValue('endTime', new Date(recruitment.volunteerEndTime));
-    setValue('deadline', new Date(recruitment.recruitmentDeadline));
+    setValue('startTime', new Date(recruitment.startTime));
+    setValue('endTime', new Date(recruitment.endTime));
+    setValue('deadline', new Date(recruitment.deadline));
     setValue('capacity', recruitment.capacity);
     setValue('content', recruitment?.content ?? '');
     setFocus('title');

--- a/packages/shared/apis/common/Recruitments.ts
+++ b/packages/shared/apis/common/Recruitments.ts
@@ -1,6 +1,6 @@
 import axiosInstance from '../axiosInstance';
 
-type RecruitmentDetailResponse = {
+export type RecruitmentDetailResponse = {
   recruitmentTitle: string;
   recruitmentApplicantCount: number;
   recruitmentCapacity: number;


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #219

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->
봉사상세조회 response 데이터의 키값을 다음과 같이 변경하여 query data 에 저장했습니다.
```
    recruitmentTitle: title,
    recruitmentContent: content,
    recruitmentApplicantCount: applicant,
    recruitmentCapacity: capacity,
    recruitmentStartTime: startTime,
    recruitmentEndTime: endTime,
    recruitmentDeadline: deadline,
    recruitmentCreatedAt: createdAt,
    recruitmentUpdatedAt: updatedAt,
    recruitmentImageUrls: imageUrls,
    recruitmentIsClosed: isClosed,
```

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->


## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- [ ] useGetVolunteerDetail 을 useFetchRecruitmentDetail 로 변경하고 싶은데 어떻게 생각하시나요?
- [ ] useQuery 대신 useSuspenseQuery 를 사용할려고 하는데 어떻게 생각하시나요?
