### PR TITLE
feat(shelter): 봉사자 모집글 리스트에서 아이템 변경시, 캐싱된 서버 상테 업데이트하는 기능 추가

### DIFF
--- a/apps/shelter/src/mocks/handlers/recruitment.ts
+++ b/apps/shelter/src/mocks/handlers/recruitment.ts
@@ -1,22 +1,25 @@
 import { delay, http, HttpResponse } from 'msw';
 
-const DUMMY_RECRUITMENT = {
-  recruitmentId: 1,
-  recruitmentTitle: '봉사자를 모집합니다',
-  recruitmentStartTime: '2021-11-08T11:44:30.327959',
-  recruitmentEndTime: '2021-11-08T11:44:30.327959',
-  recruitmentDeadline: '2023-11-20T11:44:30.327959',
-  recruitmentIsClosed: false,
-  recruitmentApplicantCount: 15,
-  recruitmentCapacity: 15,
-};
+const randomDate = (start: Date, end: Date) =>
+  new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
 
-// eslint-disable-next-line
-// @ts-ignore
-const DUMMY_RECRUITMENT_LIST = Array.from(
-  { length: 4 },
-  () => DUMMY_RECRUITMENT,
-);
+const currentDate = new Date();
+const startDate = new Date(currentDate);
+const endDate = new Date(currentDate);
+startDate.setDate(currentDate.getDate() - 30);
+endDate.setDate(endDate.getDate() + 30);
+
+const getRandomDummyRecruitment = () => ({
+  recruitmentId: Number(String(Math.random()).slice(2)),
+  shelterId: Number(String(Math.random()).slice(2)),
+  recruitmentTitle: '봉사자를 모집합니다',
+  recruitmentStartTime: randomDate(startDate, endDate),
+  recruitmentEndTime: randomDate(startDate, endDate),
+  recruitmentDeadline: randomDate(startDate, endDate),
+  recruitmentIsClosed: Boolean(Math.floor(Math.random() * 2)),
+  recruitmentApplicantCount: Math.floor(Math.random() * 15),
+  recruitmentCapacity: 20,
+});
 
 export const DUMMY_APPLICANT = {
   applicantId: 10,
@@ -44,9 +47,7 @@ export const handlers = [
           hasNext: true,
         },
         recruitments: Array.from({ length: 4 }, () => ({
-          ...DUMMY_RECRUITMENT,
-          recruitmentId: Math.random(),
-          shelterId: Math.random(),
+          ...getRandomDummyRecruitment(),
         })),
       },
       { status: 200 },


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #226

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->
봉사자 모집글 리스트에서 아이템 변경시, 캐싱된 서버 상테 업데이트하는 기능을 추가했습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
<img src="https://github.com/Anifriends/Anifriends-Frontend/assets/74397358/53afe5ca-e156-4434-bf59-87765f0504af" width="300px" />

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 봉사자 모집글 리스트에서 각기 다른 데이터를 가진 아이템을 보여주기 위해 `getRandomDummyRecruitment()` 함수를 임의로 만들었습니다