### PR TITLE
fix(shared): LocalErrorBoundary에서 로그인 이동 'login'에서 'signin'으로 변경

### DIFF
--- a/packages/shared/components/LocalErrorBoundary.tsx
+++ b/packages/shared/components/LocalErrorBoundary.tsx
@@ -1,11 +1,35 @@
 import { Button, Heading, HStack, Text, VStack } from '@chakra-ui/react';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { ReactNode } from 'react';
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
 
 import { getErrorMessage } from '../utils/errorMessage';
 
-const RetryErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+export default function LocalErrorBoundary({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary FallbackComponent={FallbackComponent} onReset={reset}>
+          {children}
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  );
+}
+
+function FallbackComponent(props: FallbackProps) {
+  // TODO accessToken 갱신 api가 정상화되면
+  //만약 401, 403, 404 혹은 그 외 에러가 발생하면 throw props.error
+
+  return <RetryErrorFallback {...props} />;
+}
+
+function RetryErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
   const navigate = useNavigate();
   const status = error?.response?.status;
   const { title, content } = getErrorMessage(status);
@@ -16,14 +40,14 @@ const RetryErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
 
   const onClick = () => {
     if (isNotAuthorized) {
-      navigate('/login');
+      navigate('/signin');
     } else {
       resetErrorBoundary();
     }
   };
 
   return (
-    <VStack justify="center" align="center" h="full" spacing="6">
+    <VStack justify="center" align="center" h="full" spacing={6}>
       <Heading as="h4" fontSize="xl">
         {title}
       </Heading>
@@ -35,28 +59,5 @@ const RetryErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
         <Button onClick={() => navigate('/volunteers')}>홈으로</Button>
       </HStack>
     </VStack>
-  );
-};
-
-const FallbackComponent = (props: FallbackProps) => {
-  // TODO accessToken 갱신 api가 정상화되면
-  //만약 401, 403, 404 혹은 그 외 에러가 발생하면 throw props.error
-
-  return <RetryErrorFallback {...props} />;
-};
-
-export default function LocalErrorBoundary({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return (
-    <QueryErrorResetBoundary>
-      {({ reset }) => (
-        <ErrorBoundary FallbackComponent={FallbackComponent} onReset={reset}>
-          {children}
-        </ErrorBoundary>
-      )}
-    </QueryErrorResetBoundary>
   );
 }

--- a/packages/shared/components/LocalErrorBoundary.tsx
+++ b/packages/shared/components/LocalErrorBoundary.tsx
@@ -6,29 +6,6 @@ import { useNavigate } from 'react-router-dom';
 
 import { getErrorMessage } from '../utils/errorMessage';
 
-export default function LocalErrorBoundary({
-  children,
-}: {
-  children: ReactNode;
-}) {
-  return (
-    <QueryErrorResetBoundary>
-      {({ reset }) => (
-        <ErrorBoundary FallbackComponent={FallbackComponent} onReset={reset}>
-          {children}
-        </ErrorBoundary>
-      )}
-    </QueryErrorResetBoundary>
-  );
-}
-
-function FallbackComponent(props: FallbackProps) {
-  // TODO accessToken 갱신 api가 정상화되면
-  //만약 401, 403, 404 혹은 그 외 에러가 발생하면 throw props.error
-
-  return <RetryErrorFallback {...props} />;
-}
-
 function RetryErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
   const navigate = useNavigate();
   const status = error?.response?.status;
@@ -59,5 +36,28 @@ function RetryErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
         <Button onClick={() => navigate('/volunteers')}>홈으로</Button>
       </HStack>
     </VStack>
+  );
+}
+
+function FallbackComponent(props: FallbackProps) {
+  // TODO accessToken 갱신 api가 정상화되면
+  //만약 401, 403, 404 혹은 그 외 에러가 발생하면 throw props.error
+
+  return <RetryErrorFallback {...props} />;
+}
+
+export default function LocalErrorBoundary({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary FallbackComponent={FallbackComponent} onReset={reset}>
+          {children}
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   );
 }


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #255 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->

* [fix(shared): LocalErrorBoundary에서 로그인 이동 'login'에서 'signin'으로 변경](https://github.com/Anifriends/Anifriends-Frontend/commit/0f5a06f4abbdc42a98f589d0c2613b16809246b4)

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
