### PR TITLE
feat(shared): 바텀 네비게이션 바와 헤더에 유저 인증 필요한 경우 모달창 띄우는 기능 추가

### DIFF
--- a/packages/shared/components/AlertModal.tsx
+++ b/packages/shared/components/AlertModal.tsx
@@ -11,8 +11,8 @@ import {
 } from '@chakra-ui/react';
 
 export type AlertModalProps = {
-  modalTitle: string;
-  modalContent: string;
+  modalTitle?: string;
+  modalContent?: string;
   btnTitle: string;
   onClick?: VoidFunction;
 } & Omit<ModalProps, 'children'>;
@@ -33,10 +33,15 @@ export default function AlertModal({
           {modalTitle}
         </ModalHeader>
         <ModalCloseButton />
-        <ModalBody>{modalContent}</ModalBody>
-
+        <ModalBody whiteSpace="pre-wrap">{modalContent}</ModalBody>
         <ModalFooter>
-          <Button colorScheme="gray" mr={3} onClick={onClose}>
+          <Button
+            colorScheme="gray"
+            mr={3}
+            onClick={onClose}
+            _active={{ bg: undefined }}
+            _hover={{ bg: undefined }}
+          >
             취소하기
           </Button>
           <Button
@@ -44,6 +49,8 @@ export default function AlertModal({
             bgColor="orange.400"
             color="white"
             onClick={onClick}
+            _active={{ bg: undefined }}
+            _hover={{ bg: undefined }}
           >
             {btnTitle}
           </Button>

--- a/packages/shared/layout/BottomNavBar/index.tsx
+++ b/packages/shared/layout/BottomNavBar/index.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@chakra-ui/react';
+import { Flex, useDisclosure } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 
 import AnimalsSelectedIcon from '../../assets/bottomNavBar/icon_animals_selected.svg';
@@ -9,63 +9,81 @@ import MyPageSeletedIcon from '../../assets/bottomNavBar/icon_mypage_selected.sv
 import MyPageUnselectedIcon from '../../assets/bottomNavBar/icon_mypage_unselected.svg';
 import VolunteersSelectedIcon from '../../assets/bottomNavBar/icon_volunteers_selected.svg';
 import VolunteersUnselectedIcon from '../../assets/bottomNavBar/icon_volunteers_unselected.svg';
+import AlertModal from '../../components/AlertModal';
 import PAGE_TYPE from '../../constants/pageType';
 import { usePageType } from '../../hooks/usePageType';
+import useAuthStore from '../../store/authStore';
 import NavBarButton from './NavBarButton';
 import { useBottomNavBar } from './useBottomNavBar';
 
 export default function BottomNavBar() {
   const { pageType } = usePageType();
   const { isBottomNavBarVisible } = useBottomNavBar(pageType);
+  const { user } = useAuthStore();
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const navigate = useNavigate();
 
   const goVolunteers = () => navigate('/volunteers');
   const goAnimals = () => navigate('/animals');
   const goChattings = () => navigate('/chattings');
-  const goMyPage = () => navigate('/mypage');
+  const goMyPage = () => (user ? navigate('/mypage') : onOpen());
+  const goLoginPage = () => {
+    navigate('/signin');
+    onClose();
+  };
 
   return (
     isBottomNavBarVisible && (
-      <Flex
-        bgColor="white"
-        w="100%"
-        h="50px"
-        px={4}
-        justifyContent="space-between"
-        borderTop="1px solid"
-        borderColor="gray.200"
-        align="center"
-        bottom={0}
-        pos="absolute"
-        zIndex={10}
-        as="nav"
-      >
-        <NavBarButton
-          selected={pageType === PAGE_TYPE.VOLUNTEERS}
-          onClick={goVolunteers}
-          buttonImageSrc={[VolunteersUnselectedIcon, VolunteersSelectedIcon]}
-          buttonText="봉사"
+      <>
+        <Flex
+          bgColor="white"
+          w="100%"
+          h="50px"
+          px={4}
+          justifyContent="space-between"
+          borderTop="1px solid"
+          borderColor="gray.200"
+          align="center"
+          bottom={0}
+          pos="absolute"
+          zIndex={10}
+          as="nav"
+        >
+          <NavBarButton
+            selected={pageType === PAGE_TYPE.VOLUNTEERS}
+            onClick={goVolunteers}
+            buttonImageSrc={[VolunteersUnselectedIcon, VolunteersSelectedIcon]}
+            buttonText="봉사"
+          />
+          <NavBarButton
+            selected={pageType === PAGE_TYPE.ANIMALS}
+            onClick={goAnimals}
+            buttonImageSrc={[AnimalsUnselectedIcon, AnimalsSelectedIcon]}
+            buttonText="입양"
+          />
+          <NavBarButton
+            selected={pageType === PAGE_TYPE.CHATTINGS}
+            onClick={goChattings}
+            buttonImageSrc={[ChattingsUnselectedIcon, ChattingsSelectedIcon]}
+            buttonText="채팅"
+          />
+          <NavBarButton
+            selected={pageType === PAGE_TYPE.MYPAGE}
+            onClick={goMyPage}
+            buttonImageSrc={[MyPageUnselectedIcon, MyPageSeletedIcon]}
+            buttonText="마이"
+          />
+        </Flex>
+        <AlertModal
+          isOpen={isOpen}
+          onClose={onClose}
+          modalTitle="로그인 페이지로 이동하기"
+          modalContent={`로그인이 필요한 서비스입니다.\n로그인 페이지로 이동하시겠습니까?`}
+          btnTitle="로그인하기"
+          onClick={goLoginPage}
         />
-        <NavBarButton
-          selected={pageType === PAGE_TYPE.ANIMALS}
-          onClick={goAnimals}
-          buttonImageSrc={[AnimalsUnselectedIcon, AnimalsSelectedIcon]}
-          buttonText="입양"
-        />
-        <NavBarButton
-          selected={pageType === PAGE_TYPE.CHATTINGS}
-          onClick={goChattings}
-          buttonImageSrc={[ChattingsUnselectedIcon, ChattingsSelectedIcon]}
-          buttonText="채팅"
-        />
-        <NavBarButton
-          selected={pageType === PAGE_TYPE.MYPAGE}
-          onClick={goMyPage}
-          buttonImageSrc={[MyPageUnselectedIcon, MyPageSeletedIcon]}
-          buttonText="마이"
-        />
-      </Flex>
+      </>
     )
   );
 }

--- a/packages/shared/layout/Header/DefaultHeader/index.tsx
+++ b/packages/shared/layout/Header/DefaultHeader/index.tsx
@@ -6,13 +6,13 @@ import {
   Text,
   useDisclosure,
 } from '@chakra-ui/react';
-import AlertModal from 'components/AlertModal';
 import { useLocation, useNavigate } from 'react-router-dom';
-import useAuthStore from 'store/authStore';
 
 import NotificationsIcon from '../../../assets/icon_notifications.svg';
 import SearchIcon from '../../../assets/icon_search.svg';
 import SettingsIcon from '../../../assets/icon_settings.svg';
+import AlertModal from '../../../components/AlertModal';
+import useAuthStore from '../../../store/authStore';
 import { HeaderProps } from '../index';
 import { useDefaultHeader } from './useDefaultHeader';
 

--- a/packages/shared/layout/Header/DefaultHeader/index.tsx
+++ b/packages/shared/layout/Header/DefaultHeader/index.tsx
@@ -1,5 +1,14 @@
-import { Box, ButtonGroup, Flex, Image, Text } from '@chakra-ui/react';
+import {
+  Box,
+  ButtonGroup,
+  Flex,
+  Image,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
+import AlertModal from 'components/AlertModal';
 import { useLocation, useNavigate } from 'react-router-dom';
+import useAuthStore from 'store/authStore';
 
 import NotificationsIcon from '../../../assets/icon_notifications.svg';
 import SearchIcon from '../../../assets/icon_search.svg';
@@ -11,47 +20,63 @@ export default function DefaultHeader({ appType }: HeaderProps) {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const { title, iconVisibility } = useDefaultHeader(appType);
+  const { user } = useAuthStore();
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const { searchIcon, settingsIcon, notificationsIcon } = iconVisibility;
 
   const goSearch = () => navigate(`${pathname}/search`);
-  const goSettings = () => navigate('/settings');
-  const goNotifications = () => navigate('/notifications');
+  const goSettings = () => (user ? navigate('/settings') : onOpen());
+  const goNotifications = () => (user ? navigate('/notifications') : onOpen());
+  const goLoginPage = () => {
+    navigate('/signin');
+    onClose();
+  };
 
   return (
-    <Flex
-      bgColor="orange.400"
-      color="white"
-      lineHeight={6}
-      pos="sticky"
-      zIndex={10}
-      w="100%"
-      py={2.5}
-      justify="center"
-      align="center"
-      top={0}
-      as="header"
-    >
-      <Text fontSize="md" fontWeight="medium" h={6}>
-        {title}
-      </Text>
-      <ButtonGroup pos="absolute" right="1rem">
-        {searchIcon && (
-          <Box onClick={goSearch} as="button">
-            <Image src={SearchIcon} alt="Search Icon" />
-          </Box>
-        )}
-        {settingsIcon && (
-          <Box onClick={goSettings} as="button">
-            <Image src={SettingsIcon} alt="Settings Icon" />
-          </Box>
-        )}
-        {notificationsIcon && (
-          <Box onClick={goNotifications} as="button">
-            <Image src={NotificationsIcon} alt="Notifications Icon" />
-          </Box>
-        )}
-      </ButtonGroup>
-    </Flex>
+    <>
+      <Flex
+        bgColor="orange.400"
+        color="white"
+        lineHeight={6}
+        pos="sticky"
+        zIndex={10}
+        w="100%"
+        py={2.5}
+        justify="center"
+        align="center"
+        top={0}
+        as="header"
+      >
+        <Text fontSize="md" fontWeight="medium" h={6}>
+          {title}
+        </Text>
+        <ButtonGroup pos="absolute" right="1rem">
+          {searchIcon && (
+            <Box onClick={goSearch} as="button">
+              <Image src={SearchIcon} alt="Search Icon" />
+            </Box>
+          )}
+          {settingsIcon && (
+            <Box onClick={goSettings} as="button">
+              <Image src={SettingsIcon} alt="Settings Icon" />
+            </Box>
+          )}
+          {notificationsIcon && (
+            <Box onClick={goNotifications} as="button">
+              <Image src={NotificationsIcon} alt="Notifications Icon" />
+            </Box>
+          )}
+        </ButtonGroup>
+      </Flex>
+      <AlertModal
+        isOpen={isOpen}
+        onClose={onClose}
+        modalTitle="로그인 페이지로 이동하기"
+        modalContent={`로그인이 필요한 서비스입니다.\n로그인 페이지로 이동하시겠습니까?`}
+        btnTitle="로그인하기"
+        onClick={goLoginPage}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #260 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->
- 바텀 네비게이션 바의 마이페이지 이동 버튼 클릭
- 헤더의 알림 페이지 이동 버튼 클릭
- 헤더의 설정 페이지 이동 버튼 클릭

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
<img src="https://github.com/Anifriends/Anifriends-Frontend/assets/74397358/15e9591e-ff8f-497c-a9c4-b39c5fd8ecc9" width="300px" />

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
