### PR TITLE
feat(shared): 이미지 resize util 함수 추가 및 useUploadPhoto hook 에 이미지 리사이징 기능 추가

### DIFF
--- a/packages/shared/components/EditPhotoItem.tsx
+++ b/packages/shared/components/EditPhotoItem.tsx
@@ -2,6 +2,7 @@ import type { ImageProps } from '@chakra-ui/react';
 import { Box, Image } from '@chakra-ui/react';
 
 import BiX from '../assets/icon_BiX.svg';
+import NoImage from '../assets/icon_no_image.svg';
 
 type UploadedPhotoItemProps = {
   photoSrc: ImageProps['src'];
@@ -35,7 +36,7 @@ export default function EditPhotoItem({
       >
         <Image src={BiX} />
       </Box>
-      <Image boxSize={100} fit="cover" src={photoSrc} />
+      <Image boxSize={100} fit="cover" src={photoSrc} fallbackSrc={NoImage} />
     </Box>
   );
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,6 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.11",
+    "react-image-file-resizer": "^0.4.8",
     "react-router-dom": "^6.17.0",
     "zod": "^3.22.4",
     "zustand": "^4.4.4"

--- a/packages/shared/utils/image.ts
+++ b/packages/shared/utils/image.ts
@@ -1,0 +1,28 @@
+import Resizer from 'react-image-file-resizer';
+
+const resize = (imageFile: File): Promise<File> => {
+  return new Promise((resolve) => {
+    Resizer.imageFileResizer(
+      imageFile,
+      1000,
+      1000,
+      'WEBP',
+      100,
+      0,
+      (uri) => resolve(uri as File),
+      'file',
+    );
+  });
+};
+
+export const resizeImageFile = async (
+  imageFile: File,
+  maxSizeMB: number,
+): Promise<File> => {
+  if (imageFile.size <= maxSizeMB * 1024 ** 2) {
+    return imageFile;
+  }
+
+  const resizedImageFile = await resize(imageFile);
+  return resizeImageFile(resizedImageFile, maxSizeMB);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       react-error-boundary:
         specifier: ^4.0.11
         version: 4.0.11(react@18.2.0)
+      react-image-file-resizer:
+        specifier: ^0.4.8
+        version: 0.4.8
       react-router-dom:
         specifier: ^6.17.0
         version: 6.18.0(react-dom@18.2.0)(react@18.2.0)
@@ -5582,6 +5585,10 @@ packages:
       react: ^16.8.0 || ^17 || ^18
     dependencies:
       react: 18.2.0
+    dev: false
+
+  /react-image-file-resizer@0.4.8:
+    resolution: {integrity: sha512-Ue7CfKnSlsfJ//SKzxNMz8avDgDSpWQDOnTKOp/GNRFJv4dO9L5YGHNEnj40peWkXXAK2OK0eRIoXhOYpUzUTQ==}
     dev: false
 
   /react-is@16.13.1:


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #251 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->
- 이미지를 특정 MB size 이하로 리사이징하는 util 함수를 추가했습니다.
- useUploadPhoto hook 에서 이미지 업로드 API 호출 전, 이미지를 2MB 이하의 크기로 리사이징하는 로직을 추가했습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
