### PR TITLE
fix(shared): LocalErrorBoundary에서 버튼 클릭 시 error boundary 초기화 과정 추가

### DIFF
--- a/packages/shared/components/LocalErrorBoundary.tsx
+++ b/packages/shared/components/LocalErrorBoundary.tsx
@@ -22,14 +22,6 @@ function RetryErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
     removeItemFromStorage(APP_TYPE.SHELTER_APP);
   }
 
-  const onClick = () => {
-    if (isNotAuthorized) {
-      navigate('/signin');
-    } else {
-      resetErrorBoundary();
-    }
-  };
-
   return (
     <VStack justify="center" align="center" h="full" spacing={6}>
       <Heading as="h4" fontSize="xl">
@@ -39,8 +31,24 @@ function RetryErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
         {content}
       </Text>
       <HStack spacing={6}>
-        {!isForbidden && <Button onClick={onClick}>{buttonMessage}</Button>}
-        <Button onClick={() => navigate('/volunteers')}>홈으로</Button>
+        {!isForbidden && (
+          <Button
+            onClick={() => {
+              resetErrorBoundary();
+              isNotAuthorized && navigate('/signin');
+            }}
+          >
+            {buttonMessage}
+          </Button>
+        )}
+        <Button
+          onClick={() => {
+            resetErrorBoundary();
+            navigate('/volunteers');
+          }}
+        >
+          홈으로
+        </Button>
       </HStack>
     </VStack>
   );


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #278 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->

* [fix(shared): LocalErrorBoundary에서 버튼 클릭 시 error boundary 초기화 과정 추가](https://github.com/Anifriends/Anifriends-Frontend/commit/72e0b80be39ae497f5519320242d4c6e7d8d08e7)

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->


https://github.com/Anifriends/Anifriends-Frontend/assets/66409882/105f00bf-ec8c-4017-ae39-5a78711f4fdb



## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

resetErrorBoundary를 버튼 클릭 시 모든 과정에 추가하여 error boundary를 초기화하였습니다!! 🙋🏻‍♂️
