### PR TITLE
fix(common): 봉사자 및 보호소 앱의 상세 페이지에서 이미지가 없으면 캐러샐 랜더하지 않도록 수정

### DIFF
--- a/apps/shelter/src/pages/volunteers/detail/index.tsx
+++ b/apps/shelter/src/pages/volunteers/detail/index.tsx
@@ -80,7 +80,9 @@ function VolunteersDetail() {
 
   return (
     <Box>
-      <ImageCarousel imageUrls={recruitment.imageUrls} />
+      {recruitment.imageUrls.length > 0 && (
+        <ImageCarousel imageUrls={recruitment.imageUrls} />
+      )}
       <VStack spacing="5px" align="flex-start" p={4}>
         <LabelText
           labelTitle={label.labelTitle}

--- a/apps/volunteer/src/pages/volunteers/detail/index.tsx
+++ b/apps/volunteer/src/pages/volunteers/detail/index.tsx
@@ -128,7 +128,9 @@ function VolunteersDetail() {
 
   return (
     <Box pb={118}>
-      <ImageCarousel imageUrls={data.recruitmentImageUrls} />
+      {data.recruitmentImageUrls.length > 0 && (
+        <ImageCarousel imageUrls={data.recruitmentImageUrls} />
+      )}
       <VStack spacing="5px" align="flex-start" p={4}>
         {isRecruitmentClosed ? (
           <Label labelTitle="마감완료" type="GRAY" />


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #205 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->
이미지 url 이 빈 배열인 경우, 이미지 캐러샐을 랜더링 하지 않도록 수정했습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
