### PR TITLE
fix(shelter): 마이페이지의 로그아웃 버튼 중복 제거 및 padding bottom 추가

### DIFF
--- a/apps/shelter/src/pages/my/index.tsx
+++ b/apps/shelter/src/pages/my/index.tsx
@@ -67,7 +67,7 @@ function ShelterMy() {
   };
 
   return (
-    <Box>
+    <Box pb="50px">
       <ProfileInfo
         infoImage={imageUrl}
         infoTitle={name}

--- a/apps/shelter/src/pages/my/index.tsx
+++ b/apps/shelter/src/pages/my/index.tsx
@@ -99,7 +99,6 @@ function ShelterMy() {
           settingItems={[
             { itemTitle: '계정 정보 수정하기', onClick: goSettingsAccount },
             { itemTitle: '비밀번호 변경하기', onClick: goSettingsPassword },
-            { itemTitle: '로그아웃하기', onClick: goSettingsPassword },
           ]}
         />
         <SettingGroup


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #305 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->
- 마이페이지의 로그아웃 버튼 중복을 제거했습니다.
- 마이페이지의 하단 padding 을 50px 추가했습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
<img width="375" alt="image" src="https://github.com/Anifriends/Anifriends-Frontend/assets/74397358/d4fe8484-5091-45c3-a88f-ed6969de7d2d">


## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
