### PR TITLE
feat: toast 알림 추가, bug 봉사자앱 계정정보수정 imageUrl { } 로 요청 수정

### DIFF
--- a/apps/shelter/src/pages/settings/account/index.tsx
+++ b/apps/shelter/src/pages/settings/account/index.tsx
@@ -29,7 +29,10 @@ const phoneRegx2 = /^(0(2|3[1-3]|4[1-4]|5[1-5]|6[1-4]))-(\d{3,4})-(\d{4})$/;
 
 const accountSchema = z.object({
   name: z.string().trim().min(1, { message: '이름은 필수입니다' }),
-  address: z.string().min(1, { message: '보호소 주소 정보는 필수입니다' }),
+  address: z
+    .string()
+    .trim()
+    .min(1, { message: '보호소 주소 정보는 필수입니다' }),
   addressDetail: z
     .string()
     .trim()
@@ -70,8 +73,13 @@ function SettingsAccount() {
         duration: 1500,
       });
     },
-    onError: (error) => {
-      console.error(error);
+    onError: () => {
+      toast({
+        position: 'top',
+        description: '계정 정보 수정이 실패했습니다.',
+        status: 'error',
+        duration: 1500,
+      });
     },
   });
 

--- a/apps/shelter/src/pages/settings/account/index.tsx
+++ b/apps/shelter/src/pages/settings/account/index.tsx
@@ -28,12 +28,12 @@ const phoneRegx1 = /^(?:(010-\d{4})|(01[1|6|7|8|9]-\d{3,4}))-(\d{4})$/;
 const phoneRegx2 = /^(0(2|3[1-3]|4[1-4]|5[1-5]|6[1-4]))-(\d{3,4})-(\d{4})$/;
 
 const accountSchema = z.object({
-  name: z.string().trim().min(2, { message: '이름은 2글자 이상입니다' }),
+  name: z.string().trim().min(1, { message: '이름은 필수입니다' }),
   address: z.string().min(1, { message: '보호소 주소 정보는 필수입니다' }),
   addressDetail: z
     .string()
     .trim()
-    .min(2, { message: '보호소 상세주소 정보는 필수입니다.' }),
+    .min(1, { message: '보호소 상세주소 정보는 필수입니다.' }),
   phoneNumber: z
     .string()
     .refine((phone) => phoneRegx1.test(phone) || phoneRegx2.test(phone), {

--- a/apps/shelter/src/pages/volunteers/detail/index.tsx
+++ b/apps/shelter/src/pages/volunteers/detail/index.tsx
@@ -30,25 +30,36 @@ import {
 
 import useGetVolunteerDetail from './_hooks/useGetVolunteerDetail';
 
-const handleDeletePost = (postId: number) => {
-  deleteShelterRecruitment(postId);
-};
-
 function VolunteersDetail() {
   const setOnDelete = useDetailHeaderStore((state) => state.setOnDelete);
-
-  const toast = useToast();
-  useEffect(() => {
-    setOnDelete(handleDeletePost);
-
-    return () => {
-      setOnDelete(() => {});
-    };
-  }, [setOnDelete]);
 
   const navigate = useNavigate();
   const { id } = useParams();
   const recruitmentId = Number(id);
+
+  const toast = useToast();
+
+  const { mutate: deleteRecruitment } = useMutation({
+    mutationFn: async (recruitmentId: number) =>
+      await deleteShelterRecruitment(recruitmentId),
+    onSuccess: () => {
+      navigate('/volunteers', { replace: true });
+      toast({
+        position: 'top',
+        description: '삭제되었습니다.',
+        status: 'success',
+        duration: 1500,
+      });
+    },
+  });
+
+  useEffect(() => {
+    setOnDelete(deleteRecruitment);
+
+    return () => {
+      setOnDelete(() => {});
+    };
+  }, [setOnDelete, deleteRecruitment]);
 
   const { isOpen, onOpen, onClose } = useDisclosure();
 

--- a/apps/volunteer/src/apis/volunteer.ts
+++ b/apps/volunteer/src/apis/volunteer.ts
@@ -26,7 +26,7 @@ export type UpdateUserInfoParams = {
   gender: 'FEMALE' | 'MALE';
   birthDate: string;
   phoneNumber: string;
-  imageUrl: string;
+  imageUrl?: string;
 };
 
 export const updateVolunteerUserInfo = (

--- a/apps/volunteer/src/pages/my/index.tsx
+++ b/apps/volunteer/src/pages/my/index.tsx
@@ -35,7 +35,7 @@ function My() {
           query={`${data.completedVolunteerCount}회`}
           styles={{ color: 'orange.400', fontWeight: 600 }}
         >
-          {`김프롱 님께서는 봉사를 ${data.completedVolunteerCount}회 완료했어요!`}
+          {`${data.volunteerName} 님께서는 봉사를 ${data.completedVolunteerCount}회 완료했어요!`}
         </Highlight>
       </Box>
       <Tabs

--- a/apps/volunteer/src/pages/volunteers/detail/_hooks/useFetchRecruitmentDetail.ts
+++ b/apps/volunteer/src/pages/volunteers/detail/_hooks/useFetchRecruitmentDetail.ts
@@ -15,7 +15,7 @@ const useFetchRecruitmentDetail = (
         queryFn: async () => (await getRecruitmentDetail(recruitmentId)).data,
       },
       {
-        queryKey: ['recruitment', recruitmentId, 'isApplied', user],
+        queryKey: ['recruitment', recruitmentId, 'isApplied'],
         queryFn: async () => {
           if (!user) {
             return { isAppliedRecruitment: false };


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #313

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->

-[x] 봉사자앱의 마이페이지에서 "OOO"님의 봉사횟수... 의 이름이 dummy 데이터로 있는것을 바꿨습니다.
-[x] 보호소앱의 모집삭제를 하면 toast 로 알림을 추가했습니다. (모달로 재확인을 하지않음)
-[x] 수정 정보 실패시 toast 로 수정이 실패했습니다를 알려줍니다.
-[x] 봉사자앱 계정정보수정에서 이미지 수정시에 imageUrl: {} 로 전송되는것을 수정했습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
